### PR TITLE
feat: add agent adapter contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ GitHub PR delivery for scoped repo tasks:
 - [`docs/product-brief.md`](docs/product-brief.md) — full product brief and naming research
 - [`docs/mvp.md`](docs/mvp.md) — initial MVP scope and milestones
 - [`docs/architecture.md`](docs/architecture.md) — first-pass architecture and data model
+- [`docs/agent-adapters.md`](docs/agent-adapters.md) — provider-neutral coding-agent adapter contract
 - [`docs/tech-stack.md`](docs/tech-stack.md) — accepted MVP stack: Electron + local orchestrator + coding-agent adapters
 - [`docs/desktop-shell.md`](docs/desktop-shell.md) — Electron main/preload/renderer boundaries and local commands
 - [`docs/plans/2026-05-02-repo-bootstrap.md`](docs/plans/2026-05-02-repo-bootstrap.md) — implementation plan for the repo bootstrap
@@ -67,6 +68,7 @@ Headless verification:
 
 ```sh
 npm run typecheck
+npm run test
 npm run smoke
 ```
 

--- a/docs/agent-adapters.md
+++ b/docs/agent-adapters.md
@@ -1,0 +1,87 @@
+# Agent Adapter Contract
+
+MergePilot workstream and orchestration code depends on the provider-neutral `@mergepilot/agents` package. Provider-specific process handling, CLI arguments, auth checks, and output parsing belong inside concrete adapter implementations.
+
+## Package
+
+The neutral contract lives in `packages/agents` and exports:
+
+- `AgentAdapter`
+- `AgentRunInput`
+- `AgentRunHandle`
+- `AgentRunEvent`
+- `AgentRunResult`
+- `AgentAdapterRegistry`
+- provider detection and health result types
+
+## Adapter Shape
+
+An adapter exposes metadata, environment detection, health checks, and a run method:
+
+```ts
+import type {
+  AgentAdapter,
+  AgentRunInput,
+  AgentRunHandle,
+} from "@mergepilot/agents";
+
+export class FutureAgentAdapter implements AgentAdapter {
+  readonly metadata = {
+    providerId: "future-agent",
+    displayName: "Future Agent",
+    capabilities: {
+      streamingEvents: true,
+      cancellation: true,
+      structuredResults: true,
+    },
+  };
+
+  async detect() {
+    return {
+      providerId: this.metadata.providerId,
+      status: "unknown",
+      checkedAt: new Date().toISOString(),
+    };
+  }
+
+  async health() {
+    return {
+      providerId: this.metadata.providerId,
+      status: "unknown",
+      checkedAt: new Date().toISOString(),
+    };
+  }
+
+  async run(input: AgentRunInput): Promise<AgentRunHandle> {
+    throw new Error(`Run ${input.runId} is not implemented yet.`);
+  }
+}
+```
+
+## Registry
+
+The registry is intentionally small. It registers adapters by `metadata.providerId`, rejects duplicate provider ids, returns adapters when orchestration needs to start a run, and lists metadata for UI or capability display without exposing implementation methods.
+
+```ts
+import { createAgentAdapterRegistry } from "@mergepilot/agents";
+
+const registry = createAgentAdapterRegistry();
+registry.register(new FutureAgentAdapter());
+
+const metadata = registry.listMetadata();
+const adapter = registry.require("future-agent");
+```
+
+The package is built as Node-compatible ESM so future local orchestrator code can import `@mergepilot/agents` directly after `npm run build`.
+
+## Adding A Future Adapter
+
+1. Create the provider-specific adapter in its own implementation package or module.
+2. Implement `AgentAdapter` from `@mergepilot/agents`.
+3. Keep provider CLI detection and health checks inside `detect` and `health`.
+4. Convert provider-specific output into `AgentRunEvent` values before orchestration sees it.
+5. Resolve `AgentRunHandle.result` with an `AgentRunResult`.
+6. Add adapter-specific tests with faked process or CLI boundaries.
+7. Register the adapter at the application composition boundary, not inside workstream domain logic.
+
+Provider ids are stable machine-readable ids such as `claude-code` or `codex`. Display names are for UI only and should not be used for lookup.

--- a/docs/agent-adapters.md
+++ b/docs/agent-adapters.md
@@ -7,6 +7,7 @@ MergePilot workstream and orchestration code depends on the provider-neutral `@m
 The neutral contract lives in `packages/agents` and exports:
 
 - `AgentAdapter`
+- `AgentAdapterInstanceId`
 - `AgentRunInput`
 - `AgentRunHandle`
 - `AgentRunEvent`
@@ -27,12 +28,14 @@ import type {
 
 export class FutureAgentAdapter implements AgentAdapter {
   readonly metadata = {
+    adapterId: "future-agent",
     providerId: "future-agent",
     displayName: "Future Agent",
     capabilities: {
       streamingEvents: true,
       cancellation: true,
       structuredResults: true,
+      sessionResume: true,
     },
   };
 
@@ -60,7 +63,9 @@ export class FutureAgentAdapter implements AgentAdapter {
 
 ## Registry
 
-The registry is intentionally small. It registers adapters by `metadata.providerId`, rejects duplicate provider ids, returns adapters when orchestration needs to start a run, and lists metadata for UI or capability display without exposing implementation methods.
+The registry is intentionally small. It registers adapters by `metadata.adapterId`, rejects duplicate adapter ids, returns adapters when orchestration needs to start a run, and lists metadata for UI or capability display without exposing implementation methods.
+
+For simple one-instance providers, `adapterId` can be omitted and defaults to `providerId`. Use an explicit `adapterId` when the same provider can be configured more than once, such as separate local runtimes, auth homes, or workspace policies.
 
 ```ts
 import { createAgentAdapterRegistry } from "@mergepilot/agents";
@@ -71,6 +76,16 @@ registry.register(new FutureAgentAdapter());
 const metadata = registry.listMetadata();
 const adapter = registry.require("future-agent");
 ```
+
+## Session Continuation
+
+Adapters that can resume provider-native sessions should declare `capabilities.sessionResume`. Orchestration passes continuation context through `AgentRunInput.session`:
+
+- `sessionKey`: MergePilot's provider-neutral lookup key for a task, chat, or workstream.
+- `resumeSessionId`: the provider-native session id returned by a previous run.
+- `handoff`: optional text for adapters that need explicit context when resuming.
+
+Adapters return new continuation state through `AgentRunResult.session`. MergePilot persistence should key that state by workstream, role, adapter id, session key, and workspace path so provider sessions do not cross repositories or configured instances.
 
 The package is built as Node-compatible ESM so future local orchestrator code can import `@mergepilot/agents` directly after `npm run build`.
 
@@ -84,4 +99,4 @@ The package is built as Node-compatible ESM so future local orchestrator code ca
 6. Add adapter-specific tests with faked process or CLI boundaries.
 7. Register the adapter at the application composition boundary, not inside workstream domain logic.
 
-Provider ids are stable machine-readable ids such as `claude-code` or `codex`. Display names are for UI only and should not be used for lookup.
+Provider ids are stable machine-readable driver ids such as `claude-code` or `codex`. Adapter ids are stable configured-instance ids and are the registry lookup key. Display names are for UI only and should not be used for lookup.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -13,7 +13,7 @@ The first built-in coding-agent adapters are:
 - Claude Code CLI
 - OpenAI Codex CLI
 
-Workstream orchestration should depend on a generic `AgentAdapter` contract, not on provider-specific logic. See [`tech-stack.md`](tech-stack.md) for the full decision.
+Workstream orchestration should depend on a generic `AgentAdapter` contract, not on provider-specific logic. The provider-neutral contract lives in `@mergepilot/agents`; see [`agent-adapters.md`](agent-adapters.md) for adapter shape and extension guidance, and [`tech-stack.md`](tech-stack.md) for the full stack decision.
 
 ## First-pass components
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -846,6 +846,10 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@mergepilot/agents": {
+      "resolved": "packages/agents",
+      "link": true
+    },
     "node_modules/@mergepilot/desktop": {
       "resolved": "apps/desktop",
       "link": true
@@ -1272,6 +1276,24 @@
         "@types/responselike": "^1.0.0"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -1366,6 +1388,121 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.4",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -1390,6 +1527,16 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/asynckit": {
@@ -1475,6 +1622,16 @@
         "node": "*"
       }
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/cacheable-lookup": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
@@ -1538,6 +1695,23 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -1566,6 +1740,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/cliui": {
@@ -1747,6 +1931,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/defer-to-connect": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
@@ -1900,6 +2094,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -1999,6 +2200,26 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/extract-zip": {
@@ -2492,6 +2713,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lowercase-keys": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
@@ -2509,6 +2737,16 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/matcher": {
@@ -2660,6 +2898,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
       }
     },
     "node_modules/pend": {
@@ -2968,6 +3223,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -2984,6 +3246,20 @@
       "dev": true,
       "license": "BSD-3-Clause",
       "optional": true
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/string-width": {
       "version": "4.2.3",
@@ -3012,6 +3288,26 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/sumchecker": {
       "version": "3.0.1",
@@ -3042,6 +3338,20 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.16",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
@@ -3056,6 +3366,36 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/tree-kill": {
@@ -3223,6 +3563,102 @@
         }
       }
     },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/pretty-format": "^3.2.4",
+        "@vitest/runner": "3.2.4",
+        "@vitest/snapshot": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.4",
+        "@vitest/ui": "3.2.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/wait-on": {
       "version": "8.0.5",
       "resolved": "https://registry.npmjs.org/wait-on/-/wait-on-8.0.5.tgz",
@@ -3257,6 +3693,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/wrap-ansi": {
@@ -3338,6 +3791,13 @@
       "dependencies": {
         "buffer-crc32": "~0.2.3",
         "fd-slicer": "~1.1.0"
+      }
+    },
+    "packages/agents": {
+      "name": "@mergepilot/agents",
+      "version": "0.0.0",
+      "devDependencies": {
+        "vitest": "^3.1.2"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -12,8 +12,9 @@
     "dev:desktop": "npm run dev -w @mergepilot/desktop",
     "build": "npm run build --workspaces --if-present",
     "typecheck": "npm run typecheck --workspaces --if-present",
-    "smoke": "npm run build && node scripts/smoke-desktop.mjs",
-    "verify": "npm run typecheck && npm run smoke"
+    "test": "npm run test --workspaces --if-present",
+    "smoke": "npm run build && node scripts/smoke-desktop.mjs && node scripts/smoke-agents.mjs",
+    "verify": "npm run typecheck && npm run test && npm run smoke"
   },
   "devDependencies": {
     "@types/node": "^22.15.3",

--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@mergepilot/agents",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "vitest run"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "devDependencies": {
+    "vitest": "^3.1.2"
+  }
+}

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -1,0 +1,2 @@
+export * from "./registry.js";
+export * from "./types.js";

--- a/packages/agents/src/registry.ts
+++ b/packages/agents/src/registry.ts
@@ -1,0 +1,52 @@
+import type {
+  AgentAdapter,
+  AgentAdapterMetadata,
+  AgentProviderId,
+} from "./types.js";
+
+export class AgentAdapterRegistry {
+  readonly #adapters = new Map<AgentProviderId, AgentAdapter>();
+
+  register(adapter: AgentAdapter): void {
+    const { providerId } = adapter.metadata;
+
+    if (!providerId) {
+      throw new Error("Agent adapter providerId is required.");
+    }
+
+    if (this.#adapters.has(providerId)) {
+      throw new Error(`Agent adapter '${providerId}' is already registered.`);
+    }
+
+    this.#adapters.set(providerId, adapter);
+  }
+
+  get(providerId: AgentProviderId): AgentAdapter | undefined {
+    return this.#adapters.get(providerId);
+  }
+
+  require(providerId: AgentProviderId): AgentAdapter {
+    const adapter = this.get(providerId);
+
+    if (!adapter) {
+      throw new Error(`Agent adapter '${providerId}' is not registered.`);
+    }
+
+    return adapter;
+  }
+
+  list(): AgentAdapter[] {
+    return Array.from(this.#adapters.values());
+  }
+
+  listMetadata(): AgentAdapterMetadata[] {
+    return this.list().map((adapter) => ({
+      ...adapter.metadata,
+      capabilities: { ...adapter.metadata.capabilities },
+    }));
+  }
+}
+
+export function createAgentAdapterRegistry(): AgentAdapterRegistry {
+  return new AgentAdapterRegistry();
+}

--- a/packages/agents/src/registry.ts
+++ b/packages/agents/src/registry.ts
@@ -1,35 +1,40 @@
 import type {
   AgentAdapter,
+  AgentAdapterInstanceId,
   AgentAdapterMetadata,
-  AgentProviderId,
 } from "./types.js";
 
 export class AgentAdapterRegistry {
-  readonly #adapters = new Map<AgentProviderId, AgentAdapter>();
+  readonly #adapters = new Map<AgentAdapterInstanceId, AgentAdapter>();
 
   register(adapter: AgentAdapter): void {
     const { providerId } = adapter.metadata;
+    const adapterId = resolveAdapterId(adapter.metadata);
 
     if (!providerId) {
       throw new Error("Agent adapter providerId is required.");
     }
 
-    if (this.#adapters.has(providerId)) {
-      throw new Error(`Agent adapter '${providerId}' is already registered.`);
+    if (!adapterId) {
+      throw new Error("Agent adapter adapterId is required.");
     }
 
-    this.#adapters.set(providerId, adapter);
+    if (this.#adapters.has(adapterId)) {
+      throw new Error(`Agent adapter '${adapterId}' is already registered.`);
+    }
+
+    this.#adapters.set(adapterId, adapter);
   }
 
-  get(providerId: AgentProviderId): AgentAdapter | undefined {
-    return this.#adapters.get(providerId);
+  get(adapterId: AgentAdapterInstanceId): AgentAdapter | undefined {
+    return this.#adapters.get(adapterId);
   }
 
-  require(providerId: AgentProviderId): AgentAdapter {
-    const adapter = this.get(providerId);
+  require(adapterId: AgentAdapterInstanceId): AgentAdapter {
+    const adapter = this.get(adapterId);
 
     if (!adapter) {
-      throw new Error(`Agent adapter '${providerId}' is not registered.`);
+      throw new Error(`Agent adapter '${adapterId}' is not registered.`);
     }
 
     return adapter;
@@ -42,11 +47,19 @@ export class AgentAdapterRegistry {
   listMetadata(): AgentAdapterMetadata[] {
     return this.list().map((adapter) => ({
       ...adapter.metadata,
+      adapterId: resolveAdapterId(adapter.metadata),
       capabilities: { ...adapter.metadata.capabilities },
+      labels: adapter.metadata.labels ? [...adapter.metadata.labels] : undefined,
     }));
   }
 }
 
 export function createAgentAdapterRegistry(): AgentAdapterRegistry {
   return new AgentAdapterRegistry();
+}
+
+function resolveAdapterId(
+  metadata: AgentAdapterMetadata,
+): AgentAdapterInstanceId {
+  return metadata.adapterId ?? metadata.providerId;
 }

--- a/packages/agents/src/types.ts
+++ b/packages/agents/src/types.ts
@@ -1,0 +1,155 @@
+export type AgentProviderId = string;
+
+export type AgentRunRole = "coordinator" | "build" | "review";
+
+export interface AgentAdapterCapabilities {
+  streamingEvents: boolean;
+  cancellation: boolean;
+  structuredResults: boolean;
+}
+
+export interface AgentAdapterMetadata {
+  providerId: AgentProviderId;
+  displayName: string;
+  version?: string;
+  capabilities: AgentAdapterCapabilities;
+}
+
+export interface AgentProviderDetectionInput {
+  cwd?: string;
+  env?: Readonly<Record<string, string | undefined>>;
+}
+
+export type AgentProviderDetectionStatus =
+  | "available"
+  | "unavailable"
+  | "unknown";
+
+export interface AgentProviderDetectionResult {
+  providerId: AgentProviderId;
+  status: AgentProviderDetectionStatus;
+  checkedAt: string;
+  message?: string;
+  version?: string;
+  executablePath?: string;
+}
+
+export interface AgentProviderHealthInput {
+  cwd?: string;
+  env?: Readonly<Record<string, string | undefined>>;
+}
+
+export type AgentProviderHealthStatus =
+  | "healthy"
+  | "degraded"
+  | "unavailable"
+  | "unknown";
+
+export interface AgentProviderHealthResult {
+  providerId: AgentProviderId;
+  status: AgentProviderHealthStatus;
+  checkedAt: string;
+  message?: string;
+  details?: Readonly<Record<string, unknown>>;
+}
+
+export interface AgentRunInput {
+  runId: string;
+  workstreamId: string;
+  role: AgentRunRole;
+  goal: string;
+  workspacePath: string;
+  repoPath?: string;
+  branchName?: string;
+  baseBranch?: string;
+  instructions?: string;
+  env?: Readonly<Record<string, string | undefined>>;
+  metadata?: Readonly<Record<string, unknown>>;
+}
+
+export type AgentRunLifecycleStatus =
+  | "queued"
+  | "started"
+  | "running"
+  | "cancelling"
+  | "completed"
+  | "failed"
+  | "cancelled";
+
+export interface BaseAgentRunEvent {
+  runId: string;
+  providerId: AgentProviderId;
+  timestamp: string;
+}
+
+export interface AgentRunLifecycleEvent extends BaseAgentRunEvent {
+  type: "lifecycle";
+  status: AgentRunLifecycleStatus;
+  message?: string;
+}
+
+export interface AgentRunMessageEvent extends BaseAgentRunEvent {
+  type: "message";
+  role: "agent" | "system";
+  content: string;
+}
+
+export interface AgentRunCommandEvent extends BaseAgentRunEvent {
+  type: "command";
+  command: string;
+  cwd?: string;
+  exitCode?: number;
+}
+
+export interface AgentRunArtifactEvent extends BaseAgentRunEvent {
+  type: "artifact";
+  artifactType: "diff" | "file" | "summary" | "log";
+  path?: string;
+  content?: string;
+  metadata?: Readonly<Record<string, unknown>>;
+}
+
+export interface AgentRunErrorEvent extends BaseAgentRunEvent {
+  type: "error";
+  message: string;
+  code?: string;
+  recoverable?: boolean;
+}
+
+export type AgentRunEvent =
+  | AgentRunLifecycleEvent
+  | AgentRunMessageEvent
+  | AgentRunCommandEvent
+  | AgentRunArtifactEvent
+  | AgentRunErrorEvent;
+
+export type AgentRunResultStatus = "completed" | "failed" | "cancelled";
+
+export interface AgentRunResult {
+  runId: string;
+  providerId: AgentProviderId;
+  status: AgentRunResultStatus;
+  summary?: string;
+  errorMessage?: string;
+  startedAt: string;
+  completedAt: string;
+  artifacts?: readonly AgentRunArtifactEvent[];
+  metadata?: Readonly<Record<string, unknown>>;
+}
+
+export interface AgentRunHandle {
+  runId: string;
+  providerId: AgentProviderId;
+  events: AsyncIterable<AgentRunEvent>;
+  result: Promise<AgentRunResult>;
+  cancel(): Promise<void>;
+}
+
+export interface AgentAdapter {
+  metadata: AgentAdapterMetadata;
+  detect(
+    input?: AgentProviderDetectionInput,
+  ): Promise<AgentProviderDetectionResult>;
+  health(input?: AgentProviderHealthInput): Promise<AgentProviderHealthResult>;
+  run(input: AgentRunInput): Promise<AgentRunHandle>;
+}

--- a/packages/agents/src/types.ts
+++ b/packages/agents/src/types.ts
@@ -1,18 +1,27 @@
 export type AgentProviderId = string;
 
+export type AgentAdapterInstanceId = string;
+
 export type AgentRunRole = "coordinator" | "build" | "review";
 
 export interface AgentAdapterCapabilities {
   streamingEvents: boolean;
   cancellation: boolean;
   structuredResults: boolean;
+  sessionResume: boolean;
 }
 
 export interface AgentAdapterMetadata {
+  /**
+   * Stable registry key for this configured adapter instance. Defaults to
+   * `providerId` when omitted so single-instance providers stay simple.
+   */
+  adapterId?: AgentAdapterInstanceId;
   providerId: AgentProviderId;
   displayName: string;
   version?: string;
   capabilities: AgentAdapterCapabilities;
+  labels?: readonly string[];
 }
 
 export interface AgentProviderDetectionInput {
@@ -64,7 +73,24 @@ export interface AgentRunInput {
   baseBranch?: string;
   instructions?: string;
   env?: Readonly<Record<string, string | undefined>>;
+  session?: AgentRunSessionInput;
   metadata?: Readonly<Record<string, unknown>>;
+}
+
+export interface AgentRunSessionInput {
+  /**
+   * Provider-neutral lookup key for persisted continuation state. Callers can
+   * scope this to a task, chat, or workstream without leaking provider ids.
+   */
+  sessionKey?: string;
+  /**
+   * Provider-native continuation id from a previous result.
+   */
+  resumeSessionId?: string;
+  /**
+   * Optional handoff text prepended by adapters that support resumable context.
+   */
+  handoff?: string;
 }
 
 export type AgentRunLifecycleStatus =
@@ -128,18 +154,28 @@ export type AgentRunResultStatus = "completed" | "failed" | "cancelled";
 export interface AgentRunResult {
   runId: string;
   providerId: AgentProviderId;
+  adapterId?: AgentAdapterInstanceId;
   status: AgentRunResultStatus;
   summary?: string;
   errorMessage?: string;
   startedAt: string;
   completedAt: string;
+  session?: AgentRunSessionResult;
   artifacts?: readonly AgentRunArtifactEvent[];
+  metadata?: Readonly<Record<string, unknown>>;
+}
+
+export interface AgentRunSessionResult {
+  sessionId: string;
+  sessionKey?: string;
+  expiresAt?: string;
   metadata?: Readonly<Record<string, unknown>>;
 }
 
 export interface AgentRunHandle {
   runId: string;
   providerId: AgentProviderId;
+  adapterId?: AgentAdapterInstanceId;
   events: AsyncIterable<AgentRunEvent>;
   result: Promise<AgentRunResult>;
   cancel(): Promise<void>;

--- a/packages/agents/test/registry.test.ts
+++ b/packages/agents/test/registry.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from "vitest";
+import {
+  AgentAdapter,
+  AgentRunInput,
+  AgentRunResult,
+  createAgentAdapterRegistry,
+} from "../src";
+
+function createFakeAdapter(providerId = "fake-agent"): AgentAdapter {
+  return {
+    metadata: {
+      providerId,
+      displayName: "Fake Agent",
+      version: "0.0.0-test",
+      capabilities: {
+        streamingEvents: true,
+        cancellation: true,
+        structuredResults: true,
+      },
+    },
+    async detect() {
+      return {
+        providerId,
+        status: "available",
+        checkedAt: "2026-05-02T00:00:00.000Z",
+        message: "Fake adapter is available for tests.",
+      };
+    },
+    async health() {
+      return {
+        providerId,
+        status: "healthy",
+        checkedAt: "2026-05-02T00:00:00.000Z",
+        message: "Fake adapter is healthy.",
+      };
+    },
+    async run(input: AgentRunInput) {
+      const result: AgentRunResult = {
+        runId: input.runId,
+        providerId,
+        status: "completed",
+        summary: "Fake run completed.",
+        startedAt: "2026-05-02T00:00:00.000Z",
+        completedAt: "2026-05-02T00:00:01.000Z",
+      };
+
+      return {
+        runId: input.runId,
+        providerId,
+        events: (async function* () {
+          yield {
+            type: "lifecycle",
+            runId: input.runId,
+            providerId,
+            timestamp: "2026-05-02T00:00:00.000Z",
+            status: "started",
+          } as const;
+        })(),
+        result: Promise.resolve(result),
+        cancel: async () => undefined,
+      };
+    },
+  };
+}
+
+describe("AgentAdapterRegistry", () => {
+  it("registers and retrieves an adapter by provider id", () => {
+    const registry = createAgentAdapterRegistry();
+    const adapter = createFakeAdapter();
+
+    registry.register(adapter);
+
+    expect(registry.get("fake-agent")).toBe(adapter);
+    expect(registry.require("fake-agent")).toBe(adapter);
+  });
+
+  it("rejects duplicate provider ids", () => {
+    const registry = createAgentAdapterRegistry();
+
+    registry.register(createFakeAdapter("fake-agent"));
+
+    expect(() => registry.register(createFakeAdapter("fake-agent"))).toThrow(
+      /already registered/i,
+    );
+  });
+
+  it("rejects adapters without provider ids", () => {
+    const registry = createAgentAdapterRegistry();
+    const adapter = createFakeAdapter("");
+
+    expect(() => registry.register(adapter)).toThrow(/providerId is required/i);
+  });
+
+  it("throws when requiring an unregistered provider id", () => {
+    const registry = createAgentAdapterRegistry();
+
+    expect(registry.get("missing-agent")).toBeUndefined();
+    expect(() => registry.require("missing-agent")).toThrow(/not registered/i);
+  });
+
+  it("lists adapter metadata without exposing provider implementations", () => {
+    const registry = createAgentAdapterRegistry();
+    const adapter = createFakeAdapter();
+
+    registry.register(adapter);
+    const metadata = registry.listMetadata();
+
+    expect(metadata).toEqual([adapter.metadata]);
+    expect(metadata[0]).not.toBe(adapter.metadata);
+    expect(metadata[0]?.capabilities).not.toBe(adapter.metadata.capabilities);
+    expect(metadata[0]).not.toHaveProperty("run");
+    expect(metadata[0]).not.toHaveProperty("health");
+    expect(registry.list()).toEqual([adapter]);
+  });
+
+  it("returns provider health and detection status through the adapter contract", async () => {
+    const registry = createAgentAdapterRegistry();
+    registry.register(createFakeAdapter("fake-agent"));
+
+    const adapter = registry.require("fake-agent");
+
+    await expect(adapter.detect()).resolves.toMatchObject({
+      providerId: "fake-agent",
+      status: "available",
+      checkedAt: expect.any(String),
+    });
+    await expect(adapter.health()).resolves.toMatchObject({
+      providerId: "fake-agent",
+      status: "healthy",
+      checkedAt: expect.any(String),
+    });
+  });
+});

--- a/packages/agents/test/registry.test.ts
+++ b/packages/agents/test/registry.test.ts
@@ -6,9 +6,13 @@ import {
   createAgentAdapterRegistry,
 } from "../src";
 
-function createFakeAdapter(providerId = "fake-agent"): AgentAdapter {
+function createFakeAdapter(
+  providerId = "fake-agent",
+  adapterId?: string,
+): AgentAdapter {
   return {
     metadata: {
+      adapterId,
       providerId,
       displayName: "Fake Agent",
       version: "0.0.0-test",
@@ -16,7 +20,9 @@ function createFakeAdapter(providerId = "fake-agent"): AgentAdapter {
         streamingEvents: true,
         cancellation: true,
         structuredResults: true,
+        sessionResume: true,
       },
+      labels: ["test"],
     },
     async detect() {
       return {
@@ -38,15 +44,23 @@ function createFakeAdapter(providerId = "fake-agent"): AgentAdapter {
       const result: AgentRunResult = {
         runId: input.runId,
         providerId,
+        adapterId,
         status: "completed",
         summary: "Fake run completed.",
         startedAt: "2026-05-02T00:00:00.000Z",
         completedAt: "2026-05-02T00:00:01.000Z",
+        session: input.session?.sessionKey
+          ? {
+              sessionId: "fake-session",
+              sessionKey: input.session.sessionKey,
+            }
+          : undefined,
       };
 
       return {
         runId: input.runId,
         providerId,
+        adapterId,
         events: (async function* () {
           yield {
             type: "lifecycle",
@@ -74,7 +88,7 @@ describe("AgentAdapterRegistry", () => {
     expect(registry.require("fake-agent")).toBe(adapter);
   });
 
-  it("rejects duplicate provider ids", () => {
+  it("rejects duplicate adapter ids", () => {
     const registry = createAgentAdapterRegistry();
 
     registry.register(createFakeAdapter("fake-agent"));
@@ -82,6 +96,28 @@ describe("AgentAdapterRegistry", () => {
     expect(() => registry.register(createFakeAdapter("fake-agent"))).toThrow(
       /already registered/i,
     );
+  });
+
+  it("allows multiple configured adapter instances for one provider", () => {
+    const registry = createAgentAdapterRegistry();
+    const personal = createFakeAdapter("fake-agent", "fake-agent-personal");
+    const work = createFakeAdapter("fake-agent", "fake-agent-work");
+
+    registry.register(personal);
+    registry.register(work);
+
+    expect(registry.get("fake-agent-personal")).toBe(personal);
+    expect(registry.get("fake-agent-work")).toBe(work);
+    expect(registry.listMetadata()).toMatchObject([
+      {
+        adapterId: "fake-agent-personal",
+        providerId: "fake-agent",
+      },
+      {
+        adapterId: "fake-agent-work",
+        providerId: "fake-agent",
+      },
+    ]);
   });
 
   it("rejects adapters without provider ids", () => {
@@ -105,9 +141,10 @@ describe("AgentAdapterRegistry", () => {
     registry.register(adapter);
     const metadata = registry.listMetadata();
 
-    expect(metadata).toEqual([adapter.metadata]);
+    expect(metadata).toEqual([{ ...adapter.metadata, adapterId: "fake-agent" }]);
     expect(metadata[0]).not.toBe(adapter.metadata);
     expect(metadata[0]?.capabilities).not.toBe(adapter.metadata.capabilities);
+    expect(metadata[0]?.labels).not.toBe(adapter.metadata.labels);
     expect(metadata[0]).not.toHaveProperty("run");
     expect(metadata[0]).not.toHaveProperty("health");
     expect(registry.list()).toEqual([adapter]);
@@ -128,6 +165,34 @@ describe("AgentAdapterRegistry", () => {
       providerId: "fake-agent",
       status: "healthy",
       checkedAt: expect.any(String),
+    });
+  });
+
+  it("passes provider-neutral session resume context through the run contract", async () => {
+    const registry = createAgentAdapterRegistry();
+    registry.register(createFakeAdapter("fake-agent", "fake-agent-main"));
+
+    const handle = await registry.require("fake-agent-main").run({
+      runId: "run-1",
+      workstreamId: "workstream-1",
+      role: "build",
+      goal: "Exercise session contract.",
+      workspacePath: "/tmp/workspace",
+      session: {
+        sessionKey: "task-1",
+        resumeSessionId: "previous-session",
+        handoff: "Continue from the previous result.",
+      },
+    });
+
+    await expect(handle.result).resolves.toMatchObject({
+      runId: "run-1",
+      providerId: "fake-agent",
+      adapterId: "fake-agent-main",
+      session: {
+        sessionId: "fake-session",
+        sessionKey: "task-1",
+      },
     });
   });
 });

--- a/packages/agents/tsconfig.json
+++ b/packages/agents/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "declaration": true,
+    "emitDeclarationOnly": false,
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "dist",
+    "rootDir": "src",
+    "noEmit": false,
+    "types": ["node", "vitest/globals"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["dist", "test"]
+}

--- a/scripts/smoke-agents.mjs
+++ b/scripts/smoke-agents.mjs
@@ -1,0 +1,20 @@
+const agents = await import("@mergepilot/agents");
+
+const requiredExports = ["AgentAdapterRegistry", "createAgentAdapterRegistry"];
+const missingExports = requiredExports.filter((exportName) => !(exportName in agents));
+
+if (missingExports.length > 0) {
+  console.error(
+    `Agents smoke failed: missing exports ${missingExports.join(", ")}`,
+  );
+  process.exit(1);
+}
+
+const registry = agents.createAgentAdapterRegistry();
+
+if (!(registry instanceof agents.AgentAdapterRegistry)) {
+  console.error("Agents smoke failed: registry factory returned an unexpected object.");
+  process.exit(1);
+}
+
+console.log("Agents smoke passed: @mergepilot/agents imports successfully.");


### PR DESCRIPTION
## Summary
- Add provider-neutral `@mergepilot/agents` workspace package
- Define `AgentAdapter`, run input/handle/event/result types, and provider detection/health result types
- Add adapter registry with duplicate/missing-provider validation and metadata listing
- Add Vitest registry coverage and a built-package import smoke check
- Document how future Claude Code, Codex, and other adapters should implement the contract

## Verification
- `npm run verify`
- `node -e "import('@mergepilot/agents').then(m => console.log(Object.keys(m).sort().join(',')))"`
- `git diff --check`
- independent implementation review: PASS

Closes #11
