### PR TITLE
feat: add Claude Code adapter

### DIFF
--- a/docs/agent-adapters.md
+++ b/docs/agent-adapters.md
@@ -77,6 +77,45 @@ const metadata = registry.listMetadata();
 const adapter = registry.require("future-agent");
 ```
 
+## Claude Code Adapter
+
+The first concrete adapter lives in `packages/claude-code-adapter` and exports `ClaudeCodeAdapter` from `@mergepilot/claude-code-adapter`.
+
+It detects the local `claude` binary with `claude --version`, performs a bounded print-mode health check, and starts one-shot runs with:
+
+```sh
+claude -p "<task>" --output-format json --max-turns <n>
+```
+
+Register it at the application composition boundary:
+
+```ts
+import { createAgentAdapterRegistry } from "@mergepilot/agents";
+import { ClaudeCodeAdapter } from "@mergepilot/claude-code-adapter";
+
+const registry = createAgentAdapterRegistry();
+
+registry.register(
+  new ClaudeCodeAdapter({
+    adapterId: "claude-code-local",
+    defaultMaxTurns: 3,
+  }),
+);
+```
+
+The adapter reads bounded turn count from `AgentRunInput.metadata.claudeMaxTurns`, falling back to `metadata.maxTurns` and then the configured default. If `AgentRunInput.session.resumeSessionId` is present, it passes that value to Claude with `--resume`; if Claude JSON output includes `session_id`, the adapter returns it as `AgentRunResult.session.sessionId`.
+
+Claude-specific process execution is isolated behind a small injected runner so tests and future orchestration code can fake CLI responses without requiring a real Claude installation or authenticated account.
+
+The Claude adapter keeps local CLI calls bounded:
+
+- detection runs use `detectTimeoutMs`, defaulting to 5 seconds;
+- health checks use `healthTimeoutMs`, defaulting to 30 seconds;
+- run output buffers are capped by `maxBufferBytes`, defaulting to 1 MiB per stream;
+- run cancellation aborts the active process and resolves the run as `cancelled`;
+- command lifecycle events redact the prompt and provider-native resume session id;
+- `defaultMaxTurns`, `metadata.claudeMaxTurns`, and `metadata.maxTurns` are capped at 50.
+
 ## Session Continuation
 
 Adapters that can resume provider-native sessions should declare `capabilities.sessionResume`. Orchestration passes continuation context through `AgentRunInput.session`:

--- a/package-lock.json
+++ b/package-lock.json
@@ -850,6 +850,10 @@
       "resolved": "packages/agents",
       "link": true
     },
+    "node_modules/@mergepilot/claude-code-adapter": {
+      "resolved": "packages/claude-code-adapter",
+      "link": true
+    },
     "node_modules/@mergepilot/desktop": {
       "resolved": "apps/desktop",
       "link": true
@@ -3796,6 +3800,16 @@
     "packages/agents": {
       "name": "@mergepilot/agents",
       "version": "0.0.0",
+      "devDependencies": {
+        "vitest": "^3.1.2"
+      }
+    },
+    "packages/claude-code-adapter": {
+      "name": "@mergepilot/claude-code-adapter",
+      "version": "0.0.0",
+      "dependencies": {
+        "@mergepilot/agents": "0.0.0"
+      },
       "devDependencies": {
         "vitest": "^3.1.2"
       }

--- a/packages/claude-code-adapter/package.json
+++ b/packages/claude-code-adapter/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@mergepilot/claude-code-adapter",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "vitest run"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "dependencies": {
+    "@mergepilot/agents": "0.0.0"
+  },
+  "devDependencies": {
+    "vitest": "^3.1.2"
+  }
+}

--- a/packages/claude-code-adapter/src/index.ts
+++ b/packages/claude-code-adapter/src/index.ts
@@ -1,0 +1,586 @@
+import type {
+  AgentAdapter,
+  AgentAdapterMetadata,
+  AgentProviderDetectionInput,
+  AgentProviderDetectionResult,
+  AgentProviderHealthInput,
+  AgentProviderHealthResult,
+  AgentRunArtifactEvent,
+  AgentRunEvent,
+  AgentRunHandle,
+  AgentRunInput,
+  AgentRunResult,
+} from "@mergepilot/agents";
+import {
+  ClaudeCliRunner,
+  ClaudeCliRunRequest,
+  ClaudeCliRunResult,
+  SpawnClaudeCliRunner,
+} from "./process-runner.js";
+
+export type {
+  ClaudeCliRunner,
+  ClaudeCliRunRequest,
+  ClaudeCliRunResult,
+} from "./process-runner.js";
+
+export interface ClaudeCodeAdapterOptions {
+  adapterId?: string;
+  executable?: string;
+  defaultMaxTurns?: number;
+  detectTimeoutMs?: number;
+  healthTimeoutMs?: number;
+  maxBufferBytes?: number;
+  runner?: ClaudeCliRunner;
+}
+
+const PROVIDER_ID = "claude-code";
+const DEFAULT_MAX_TURNS = 3;
+const MAX_MAX_TURNS = 50;
+const DEFAULT_DETECT_TIMEOUT_MS = 5_000;
+const DEFAULT_HEALTH_TIMEOUT_MS = 30_000;
+const DEFAULT_MAX_BUFFER_BYTES = 1024 * 1024;
+const REDACTED = "[redacted]";
+
+export class ClaudeCodeAdapter implements AgentAdapter {
+  readonly #executable: string;
+  readonly #defaultMaxTurns: number;
+  readonly #detectTimeoutMs: number;
+  readonly #healthTimeoutMs: number;
+  readonly #maxBufferBytes: number;
+  readonly #runner: ClaudeCliRunner;
+
+  readonly metadata: AgentAdapterMetadata;
+
+  constructor(options: ClaudeCodeAdapterOptions = {}) {
+    this.#executable = options.executable ?? "claude";
+    this.#defaultMaxTurns = normalizeMaxTurns(
+      options.defaultMaxTurns,
+      DEFAULT_MAX_TURNS,
+    );
+    this.#detectTimeoutMs = normalizePositiveInteger(
+      options.detectTimeoutMs,
+      DEFAULT_DETECT_TIMEOUT_MS,
+    );
+    this.#healthTimeoutMs = normalizePositiveInteger(
+      options.healthTimeoutMs,
+      DEFAULT_HEALTH_TIMEOUT_MS,
+    );
+    this.#maxBufferBytes = normalizePositiveInteger(
+      options.maxBufferBytes,
+      DEFAULT_MAX_BUFFER_BYTES,
+    );
+    this.#runner = options.runner ?? new SpawnClaudeCliRunner();
+    this.metadata = {
+      adapterId: options.adapterId,
+      providerId: PROVIDER_ID,
+      displayName: "Claude Code",
+      capabilities: {
+        streamingEvents: false,
+        cancellation: true,
+        structuredResults: true,
+        sessionResume: true,
+      },
+      labels: ["local-cli", "first-party"],
+    };
+  }
+
+  async detect(
+    input: AgentProviderDetectionInput = {},
+  ): Promise<AgentProviderDetectionResult> {
+    const checkedAt = new Date().toISOString();
+    const result = await this.#runCli({
+      command: this.#executable,
+      args: ["--version"],
+      cwd: input.cwd,
+      env: input.env,
+      timeoutMs: this.#detectTimeoutMs,
+    });
+
+    if (result.timedOut) {
+      return {
+        providerId: PROVIDER_ID,
+        status: "unknown",
+        checkedAt,
+        message: `Claude Code CLI detection timed out after ${this.#detectTimeoutMs}ms.`,
+      };
+    }
+
+    if (isMissingBinary(result)) {
+      return {
+        providerId: PROVIDER_ID,
+        status: "unavailable",
+        checkedAt,
+        message: `Claude Code CLI '${this.#executable}' was not found.`,
+      };
+    }
+
+    if (result.exitCode === 0) {
+      const version = firstLine(result.stdout) ?? firstLine(result.stderr);
+      return {
+        providerId: PROVIDER_ID,
+        status: "available",
+        checkedAt,
+        message: version
+          ? `Claude Code CLI is installed: ${version}.`
+          : "Claude Code CLI is installed.",
+        version,
+        executablePath: this.#executable,
+      };
+    }
+
+    return {
+      providerId: PROVIDER_ID,
+      status: "unavailable",
+      checkedAt,
+      message:
+        firstLine(result.stderr) ??
+        firstLine(result.stdout) ??
+        `Claude Code CLI exited with code ${result.exitCode}.`,
+    };
+  }
+
+  async health(
+    input: AgentProviderHealthInput = {},
+  ): Promise<AgentProviderHealthResult> {
+    const detected = await this.detect(input);
+    const checkedAt = new Date().toISOString();
+
+    if (detected.status !== "available") {
+      return {
+        providerId: PROVIDER_ID,
+        status: detected.status === "unknown" ? "unknown" : "unavailable",
+        checkedAt,
+        message: detected.message,
+        details: { detectionStatus: detected.status },
+      };
+    }
+
+    const result = await this.#runCli({
+      command: this.#executable,
+      args: [
+        "-p",
+        "Reply with OK only.",
+        "--output-format",
+        "json",
+        "--max-turns",
+        "1",
+      ],
+      cwd: input.cwd,
+      env: input.env,
+      timeoutMs: this.#healthTimeoutMs,
+    });
+
+    if (result.timedOut) {
+      return {
+        providerId: PROVIDER_ID,
+        status: "unknown",
+        checkedAt,
+        message: `Claude Code health check timed out after ${this.#healthTimeoutMs}ms.`,
+        details: {
+          reason: "timeout",
+          version: detected.version,
+        },
+      };
+    }
+
+    if (result.exitCode === 0) {
+      return {
+        providerId: PROVIDER_ID,
+        status: "healthy",
+        checkedAt,
+        message: "Claude Code CLI is installed and accepted a bounded print-mode run.",
+        details: { version: detected.version },
+      };
+    }
+
+    const message =
+      firstLine(result.stderr) ??
+      firstLine(result.stdout) ??
+      `Claude Code health check exited with code ${result.exitCode}.`;
+
+    return {
+      providerId: PROVIDER_ID,
+      status: "degraded",
+      checkedAt,
+      message,
+      details: {
+        reason: looksUnauthenticated(message) ? "unauthenticated" : "unavailable",
+        exitCode: result.exitCode,
+        version: detected.version,
+      },
+    };
+  }
+
+  async run(input: AgentRunInput): Promise<AgentRunHandle> {
+    const abortController = new AbortController();
+    const execution = this.#executeRun(input, abortController.signal);
+
+    return {
+      runId: input.runId,
+      providerId: PROVIDER_ID,
+      adapterId: this.metadata.adapterId,
+      events: (async function* () {
+        const { events } = await execution;
+        yield* events;
+      })(),
+      result: execution.then(({ result }) => result),
+      cancel: async () => {
+        abortController.abort();
+      },
+    };
+  }
+
+  async #executeRun(
+    input: AgentRunInput,
+    signal: AbortSignal,
+  ): Promise<{ events: AgentRunEvent[]; result: AgentRunResult }> {
+    const startedAt = new Date().toISOString();
+    const artifacts: AgentRunArtifactEvent[] = [];
+    const events: AgentRunEvent[] = [
+      lifecycleEvent(input.runId, startedAt, "started", "Claude Code run started."),
+    ];
+    const prompt = buildPrompt(input);
+    const maxTurns = resolveMaxTurns(input.metadata, this.#defaultMaxTurns);
+    const args = [
+      "-p",
+      prompt,
+      "--output-format",
+      "json",
+      "--max-turns",
+      String(maxTurns),
+      ...resumeArgs(input.session?.resumeSessionId),
+    ];
+
+    events.push({
+      type: "command",
+      runId: input.runId,
+      providerId: PROVIDER_ID,
+      timestamp: startedAt,
+      command: formatCommand(this.#executable, args),
+      cwd: input.workspacePath,
+    });
+
+    const cliResult = await this.#runCli({
+      command: this.#executable,
+      args,
+      cwd: input.workspacePath,
+      env: input.env,
+      signal,
+    });
+    const completedAt = new Date().toISOString();
+    const parsed = parseClaudeOutput(cliResult.stdout);
+    const cancelled = signal.aborted || isAbortedResult(cliResult);
+
+    if (cliResult.stdout.trim()) {
+      const event = artifactEvent(input.runId, completedAt, "log", {
+        content: cliResult.stdout,
+        metadata: { stream: "stdout" },
+      });
+      artifacts.push(event);
+      events.push(event);
+    }
+
+    if (cliResult.stderr.trim()) {
+      const event = artifactEvent(input.runId, completedAt, "log", {
+        content: cliResult.stderr,
+        metadata: { stream: "stderr" },
+      });
+      artifacts.push(event);
+      events.push(event);
+    }
+
+    const summary = parsed.summary ?? fallbackSummary(cliResult);
+
+    if (summary) {
+      events.push({
+        type: "message",
+        runId: input.runId,
+        providerId: PROVIDER_ID,
+        timestamp: completedAt,
+        role: "agent",
+        content: summary,
+      });
+      const event = artifactEvent(input.runId, completedAt, "summary", {
+        content: summary,
+      });
+      artifacts.push(event);
+      events.push(event);
+    }
+
+    const status = cancelled
+      ? "cancelled"
+      : cliResult.exitCode === 0
+        ? "completed"
+        : "failed";
+    const errorMessage =
+      status === "failed"
+        ? firstLine(cliResult.stderr) ??
+          firstLine(cliResult.stdout) ??
+          `Claude Code exited with code ${cliResult.exitCode}.`
+        : undefined;
+
+    if (errorMessage) {
+      events.push({
+        type: "error",
+        runId: input.runId,
+        providerId: PROVIDER_ID,
+        timestamp: completedAt,
+        message: errorMessage,
+        code:
+          typeof cliResult.exitCode === "number"
+            ? `CLAUDE_EXIT_${cliResult.exitCode}`
+            : "CLAUDE_PROCESS_ERROR",
+        recoverable: false,
+      });
+    }
+
+    events.push(
+      lifecycleEvent(
+        input.runId,
+        completedAt,
+        status,
+        status === "completed"
+          ? "Claude Code run completed."
+          : status === "cancelled"
+            ? "Claude Code run cancelled."
+            : "Claude Code run failed.",
+      ),
+    );
+
+    return {
+      events,
+      result: {
+        runId: input.runId,
+        providerId: PROVIDER_ID,
+        adapterId: this.metadata.adapterId,
+        status,
+        summary,
+        errorMessage,
+        startedAt,
+        completedAt,
+        session: parsed.sessionId
+          ? {
+              sessionId: parsed.sessionId,
+              sessionKey: input.session?.sessionKey,
+            }
+          : undefined,
+        artifacts,
+        metadata: {
+          exitCode: cliResult.exitCode,
+          outputFormat: parsed.rawJson ? "json" : "text",
+          maxTurns,
+          cancelled,
+          stdoutTruncated: cliResult.stdoutTruncated || undefined,
+          stderrTruncated: cliResult.stderrTruncated || undefined,
+        },
+      },
+    };
+  }
+
+  async #runCli(request: ClaudeCliRunRequest): Promise<ClaudeCliRunResult> {
+    try {
+      return await this.#runner.run({
+        maxBufferBytes: this.#maxBufferBytes,
+        ...request,
+      });
+    } catch (error) {
+      return {
+        exitCode: null,
+        stdout: "",
+        stderr: error instanceof Error ? error.message : String(error),
+        error,
+      };
+    }
+  }
+}
+
+function lifecycleEvent(
+  runId: string,
+  timestamp: string,
+  status: "started" | "completed" | "failed" | "cancelled",
+  message: string,
+): AgentRunEvent {
+  return {
+    type: "lifecycle",
+    runId,
+    providerId: PROVIDER_ID,
+    timestamp,
+    status,
+    message,
+  };
+}
+
+function artifactEvent(
+  runId: string,
+  timestamp: string,
+  artifactType: AgentRunArtifactEvent["artifactType"],
+  event: Pick<AgentRunArtifactEvent, "content" | "metadata">,
+): AgentRunArtifactEvent {
+  return {
+    type: "artifact",
+    runId,
+    providerId: PROVIDER_ID,
+    timestamp,
+    artifactType,
+    ...event,
+  };
+}
+
+function buildPrompt(input: AgentRunInput): string {
+  return [input.session?.handoff, input.goal, input.instructions]
+    .filter((value): value is string => Boolean(value?.trim()))
+    .join("\n\n");
+}
+
+function resumeArgs(resumeSessionId?: string): string[] {
+  return resumeSessionId ? ["--resume", resumeSessionId] : [];
+}
+
+function resolveMaxTurns(
+  metadata: Readonly<Record<string, unknown>> | undefined,
+  defaultMaxTurns: number,
+): number {
+  const value = metadata?.claudeMaxTurns ?? metadata?.maxTurns;
+  return normalizeMaxTurns(value, defaultMaxTurns);
+}
+
+function normalizeMaxTurns(value: unknown, fallback: number): number {
+  const normalized = normalizePositiveInteger(value, fallback);
+  return Math.min(normalized, MAX_MAX_TURNS);
+}
+
+function normalizePositiveInteger(value: unknown, fallback: number): number {
+  return typeof value === "number" && Number.isInteger(value) && value > 0
+    ? value
+    : fallback;
+}
+
+function parseClaudeOutput(stdout: string): {
+  rawJson?: unknown;
+  summary?: string;
+  sessionId?: string;
+} {
+  const trimmed = stdout.trim();
+
+  if (!trimmed) {
+    return {};
+  }
+
+  try {
+    const rawJson: unknown = JSON.parse(trimmed);
+    return {
+      rawJson,
+      summary: extractSummary(rawJson),
+      sessionId: extractString(rawJson, ["session_id", "sessionId"]),
+    };
+  } catch {
+    return { summary: trimmed };
+  }
+}
+
+function extractSummary(value: unknown): string | undefined {
+  if (typeof value === "string") {
+    return value;
+  }
+
+  if (!isRecord(value)) {
+    return undefined;
+  }
+
+  for (const key of ["result", "summary", "message", "content", "text"]) {
+    const nested = value[key];
+    if (typeof nested === "string" && nested.trim()) {
+      return nested;
+    }
+  }
+
+  return undefined;
+}
+
+function extractString(value: unknown, keys: readonly string[]): string | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+
+  for (const key of keys) {
+    const nested = value[key];
+    if (typeof nested === "string" && nested.trim()) {
+      return nested;
+    }
+  }
+
+  return undefined;
+}
+
+function fallbackSummary(result: ClaudeCliRunResult): string | undefined {
+  return firstLine(result.stdout) ?? firstLine(result.stderr);
+}
+
+function firstLine(value: string): string | undefined {
+  const line = value
+    .split(/\r?\n/)
+    .map((entry) => entry.trim())
+    .find(Boolean);
+
+  return line || undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isMissingBinary(result: ClaudeCliRunResult): boolean {
+  if (isNodeError(result.error) && result.error.code === "ENOENT") {
+    return true;
+  }
+
+  return result.exitCode === null && /ENOENT|not found/i.test(String(result.error));
+}
+
+function isAbortedResult(result: ClaudeCliRunResult): boolean {
+  if (result.aborted) {
+    return true;
+  }
+
+  return isAbortError(result.error);
+}
+
+function isAbortError(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    (error.name === "AbortError" || /abort/i.test(error.message))
+  );
+}
+
+function isNodeError(error: unknown): error is NodeJS.ErrnoException {
+  return error instanceof Error;
+}
+
+function looksUnauthenticated(message: string): boolean {
+  return /auth|login|credential|api key|unauthor/i.test(message);
+}
+
+function formatCommand(command: string, args: readonly string[]): string {
+  return [command, ...redactCommandArgs(args).map(quoteArg)].join(" ");
+}
+
+function redactCommandArgs(args: readonly string[]): string[] {
+  const redacted = [...args];
+
+  for (const option of ["-p", "--prompt", "--resume"]) {
+    const index = redacted.indexOf(option);
+
+    if (index >= 0 && index + 1 < redacted.length) {
+      redacted[index + 1] = REDACTED;
+    }
+  }
+
+  return redacted;
+}
+
+function quoteArg(value: string): string {
+  return /^[A-Za-z0-9_./:=@-]+$/.test(value)
+    ? value
+    : JSON.stringify(value);
+}

--- a/packages/claude-code-adapter/src/process-runner.ts
+++ b/packages/claude-code-adapter/src/process-runner.ts
@@ -1,0 +1,137 @@
+import { spawn } from "node:child_process";
+
+export interface ClaudeCliRunRequest {
+  command: string;
+  args: readonly string[];
+  cwd?: string;
+  env?: Readonly<Record<string, string | undefined>>;
+  signal?: AbortSignal;
+  timeoutMs?: number;
+  maxBufferBytes?: number;
+}
+
+export interface ClaudeCliRunResult {
+  exitCode: number | null;
+  stdout: string;
+  stderr: string;
+  error?: unknown;
+  signal?: NodeJS.Signals | null;
+  aborted?: boolean;
+  timedOut?: boolean;
+  stdoutTruncated?: boolean;
+  stderrTruncated?: boolean;
+}
+
+export interface ClaudeCliRunner {
+  run(request: ClaudeCliRunRequest): Promise<ClaudeCliRunResult>;
+}
+
+const DEFAULT_MAX_BUFFER_BYTES = 1024 * 1024;
+
+export class SpawnClaudeCliRunner implements ClaudeCliRunner {
+  run(request: ClaudeCliRunRequest): Promise<ClaudeCliRunResult> {
+    return new Promise((resolve) => {
+      const controller = new AbortController();
+      const abort = () => controller.abort();
+      const timeoutMs = normalizeTimeoutMs(request.timeoutMs);
+      const timeout = timeoutMs
+        ? setTimeout(() => {
+            timedOut = true;
+            controller.abort();
+          }, timeoutMs)
+        : undefined;
+      let timedOut = false;
+
+      if (request.signal?.aborted) {
+        controller.abort();
+      } else {
+        request.signal?.addEventListener("abort", abort, { once: true });
+      }
+
+      const child = spawn(request.command, request.args, {
+        cwd: request.cwd,
+        env: mergeEnv(request.env),
+        signal: controller.signal,
+        windowsHide: true,
+      });
+      const stdout: Buffer[] = [];
+      const stderr: Buffer[] = [];
+      const maxBufferBytes = normalizeMaxBufferBytes(request.maxBufferBytes);
+      let stdoutBytes = 0;
+      let stderrBytes = 0;
+      let stdoutTruncated = false;
+      let stderrTruncated = false;
+      let spawnError: unknown;
+
+      child.stdout.on("data", (chunk: Buffer) => {
+        const result = appendBoundedBuffer(stdout, stdoutBytes, chunk, maxBufferBytes);
+        stdoutBytes = result.bytes;
+        stdoutTruncated ||= result.truncated;
+      });
+      child.stderr.on("data", (chunk: Buffer) => {
+        const result = appendBoundedBuffer(stderr, stderrBytes, chunk, maxBufferBytes);
+        stderrBytes = result.bytes;
+        stderrTruncated ||= result.truncated;
+      });
+      child.on("error", (error) => {
+        spawnError = error;
+      });
+      child.on("close", (exitCode, signal) => {
+        if (timeout) {
+          clearTimeout(timeout);
+        }
+        request.signal?.removeEventListener("abort", abort);
+        resolve({
+          exitCode,
+          stdout: Buffer.concat(stdout).toString("utf8"),
+          stderr: Buffer.concat(stderr).toString("utf8"),
+          error: spawnError,
+          signal,
+          aborted: controller.signal.aborted,
+          timedOut,
+          stdoutTruncated,
+          stderrTruncated,
+        });
+      });
+    });
+  }
+}
+
+function appendBoundedBuffer(
+  chunks: Buffer[],
+  existingBytes: number,
+  chunk: Buffer,
+  maxBufferBytes: number,
+): { bytes: number; truncated: boolean } {
+  const remainingBytes = maxBufferBytes - existingBytes;
+
+  if (remainingBytes <= 0) {
+    return { bytes: existingBytes, truncated: true };
+  }
+
+  if (chunk.byteLength <= remainingBytes) {
+    chunks.push(chunk);
+    return { bytes: existingBytes + chunk.byteLength, truncated: false };
+  }
+
+  chunks.push(chunk.subarray(0, remainingBytes));
+  return { bytes: maxBufferBytes, truncated: true };
+}
+
+function normalizeTimeoutMs(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) && value > 0
+    ? value
+    : undefined;
+}
+
+function normalizeMaxBufferBytes(value: unknown): number {
+  return typeof value === "number" && Number.isInteger(value) && value > 0
+    ? value
+    : DEFAULT_MAX_BUFFER_BYTES;
+}
+
+function mergeEnv(
+  env?: Readonly<Record<string, string | undefined>>,
+): NodeJS.ProcessEnv | undefined {
+  return env ? { ...process.env, ...env } : undefined;
+}

--- a/packages/claude-code-adapter/test/claude-code-adapter.test.ts
+++ b/packages/claude-code-adapter/test/claude-code-adapter.test.ts
@@ -1,0 +1,373 @@
+import { describe, expect, it } from "vitest";
+import {
+  ClaudeCliRunner,
+  ClaudeCliRunRequest,
+  ClaudeCliRunResult,
+  ClaudeCodeAdapter,
+} from "../src/index.js";
+
+class FakeRunner implements ClaudeCliRunner {
+  readonly requests: ClaudeCliRunRequest[] = [];
+  #results: ClaudeCliRunResult[];
+
+  constructor(results: ClaudeCliRunResult[]) {
+    this.#results = [...results];
+  }
+
+  async run(request: ClaudeCliRunRequest): Promise<ClaudeCliRunResult> {
+    this.requests.push(request);
+    const result = this.#results.shift();
+
+    if (!result) {
+      throw new Error("Unexpected fake Claude CLI request.");
+    }
+
+    return result;
+  }
+}
+
+class AbortAwareRunner implements ClaudeCliRunner {
+  readonly requests: ClaudeCliRunRequest[] = [];
+
+  run(request: ClaudeCliRunRequest): Promise<ClaudeCliRunResult> {
+    this.requests.push(request);
+
+    return new Promise((resolve) => {
+      request.signal?.addEventListener(
+        "abort",
+        () => {
+          resolve({
+            exitCode: null,
+            stdout: "",
+            stderr: "",
+            error: Object.assign(new Error("The operation was aborted."), {
+              name: "AbortError",
+            }),
+            aborted: true,
+          });
+        },
+        { once: true },
+      );
+    });
+  }
+}
+
+const success = (stdout = ""): ClaudeCliRunResult => ({
+  exitCode: 0,
+  stdout,
+  stderr: "",
+});
+
+const failure = (stderr: string, exitCode = 1): ClaudeCliRunResult => ({
+  exitCode,
+  stdout: "",
+  stderr,
+});
+
+async function collect<T>(iterable: AsyncIterable<T>): Promise<T[]> {
+  const values: T[] = [];
+
+  for await (const value of iterable) {
+    values.push(value);
+  }
+
+  return values;
+}
+
+describe("ClaudeCodeAdapter", () => {
+  it("reports detection and healthy auth status", async () => {
+    const runner = new FakeRunner([
+      success("claude 1.2.3\n"),
+      success("claude 1.2.3\n"),
+      success(JSON.stringify({ result: "OK" })),
+    ]);
+    const adapter = new ClaudeCodeAdapter({ runner });
+
+    await expect(adapter.detect()).resolves.toMatchObject({
+      providerId: "claude-code",
+      status: "available",
+      version: "claude 1.2.3",
+      executablePath: "claude",
+    });
+
+    await expect(adapter.health({ cwd: "/tmp/repo" })).resolves.toMatchObject({
+      providerId: "claude-code",
+      status: "healthy",
+    });
+
+    expect(runner.requests[0]).toMatchObject({
+      command: "claude",
+      args: ["--version"],
+      timeoutMs: 5000,
+    });
+    expect(runner.requests[2]).toMatchObject({
+      cwd: "/tmp/repo",
+      args: [
+        "-p",
+        "Reply with OK only.",
+        "--output-format",
+        "json",
+        "--max-turns",
+        "1",
+      ],
+      timeoutMs: 30000,
+    });
+  });
+
+  it("bounds detection and health checks with configurable timeouts", async () => {
+    const runner = new FakeRunner([
+      { exitCode: null, stdout: "", stderr: "", timedOut: true },
+      success("claude 1.2.3\n"),
+      { exitCode: null, stdout: "", stderr: "", timedOut: true },
+    ]);
+    const adapter = new ClaudeCodeAdapter({
+      runner,
+      detectTimeoutMs: 123,
+      healthTimeoutMs: 456,
+    });
+
+    await expect(adapter.detect()).resolves.toMatchObject({
+      status: "unknown",
+      message: expect.stringContaining("123ms"),
+    });
+    await expect(adapter.health()).resolves.toMatchObject({
+      status: "unknown",
+      message: expect.stringContaining("456ms"),
+      details: { reason: "timeout" },
+    });
+
+    expect(runner.requests[0]).toMatchObject({ args: ["--version"], timeoutMs: 123 });
+    expect(runner.requests[1]).toMatchObject({ args: ["--version"], timeoutMs: 123 });
+    expect(runner.requests[2]).toMatchObject({ timeoutMs: 456 });
+  });
+
+  it("distinguishes missing binary and unauthenticated health", async () => {
+    const missing = new FakeRunner([
+      { exitCode: null, stdout: "", stderr: "", error: Object.assign(new Error("spawn ENOENT"), { code: "ENOENT" }) },
+    ]);
+    const unauthenticated = new FakeRunner([
+      success("claude 1.2.3\n"),
+      failure("Please login to Claude first.\n"),
+    ]);
+
+    await expect(new ClaudeCodeAdapter({ runner: missing }).detect()).resolves.toMatchObject({
+      status: "unavailable",
+      message: expect.stringMatching(/not found/i),
+    });
+
+    await expect(new ClaudeCodeAdapter({ runner: unauthenticated }).health()).resolves.toMatchObject({
+      status: "degraded",
+      details: { reason: "unauthenticated" },
+    });
+  });
+
+  it("runs Claude print mode in the workspace and normalizes JSON output", async () => {
+    const runner = new FakeRunner([
+      success(JSON.stringify({ result: "Implemented the task.", session_id: "session-123" })),
+    ]);
+    const adapter = new ClaudeCodeAdapter({
+      adapterId: "claude-main",
+      runner,
+      defaultMaxTurns: 2,
+    });
+
+    const handle = await adapter.run({
+      runId: "run-1",
+      workstreamId: "workstream-1",
+      role: "build",
+      goal: "Implement issue 12.",
+      workspacePath: "/tmp/workspace",
+      instructions: "Keep changes focused.",
+      session: {
+        sessionKey: "issue-12",
+        resumeSessionId: "session-previous",
+        handoff: "Continue prior context.",
+      },
+      metadata: {
+        claudeMaxTurns: 7,
+      },
+    });
+
+    const [events, result] = await Promise.all([
+      collect(handle.events),
+      handle.result,
+    ]);
+
+    expect(runner.requests[0]).toMatchObject({
+      command: "claude",
+      cwd: "/tmp/workspace",
+      args: [
+        "-p",
+        "Continue prior context.\n\nImplement issue 12.\n\nKeep changes focused.",
+        "--output-format",
+        "json",
+        "--max-turns",
+        "7",
+        "--resume",
+        "session-previous",
+      ],
+    });
+    expect(result).toMatchObject({
+      runId: "run-1",
+      providerId: "claude-code",
+      adapterId: "claude-main",
+      status: "completed",
+      summary: "Implemented the task.",
+      session: {
+        sessionId: "session-123",
+        sessionKey: "issue-12",
+      },
+      metadata: {
+        exitCode: 0,
+        outputFormat: "json",
+        maxTurns: 7,
+      },
+    });
+    expect(events).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: "lifecycle", status: "started" }),
+        expect.objectContaining({ type: "command", cwd: "/tmp/workspace" }),
+        expect.objectContaining({ type: "artifact", artifactType: "log" }),
+        expect.objectContaining({
+          type: "message",
+          role: "agent",
+          content: "Implemented the task.",
+        }),
+        expect.objectContaining({
+          type: "lifecycle",
+          status: "completed",
+        }),
+      ]),
+    );
+
+    const commandEvent = events.find((event) => event.type === "command");
+    expect(commandEvent).toMatchObject({
+      type: "command",
+      command: 'claude -p "[redacted]" --output-format json --max-turns 7 --resume "[redacted]"',
+    });
+    expect(commandEvent).not.toMatchObject({
+      command: expect.stringContaining("session-previous"),
+    });
+    expect(commandEvent).not.toMatchObject({
+      command: expect.stringContaining("Implement issue 12."),
+    });
+  });
+
+  it("caps max turns to a bounded upper limit", async () => {
+    const runner = new FakeRunner([
+      success(JSON.stringify({ result: "Done." })),
+    ]);
+    const adapter = new ClaudeCodeAdapter({
+      runner,
+      defaultMaxTurns: 99,
+    });
+
+    const handle = await adapter.run({
+      runId: "run-max-turns",
+      workstreamId: "workstream-1",
+      role: "build",
+      goal: "Use a bounded turn count.",
+      workspacePath: "/tmp/workspace",
+      metadata: {
+        claudeMaxTurns: 999,
+      },
+    });
+    const result = await handle.result;
+
+    expect(runner.requests[0]?.args).toContain("50");
+    expect(result.metadata).toMatchObject({ maxTurns: 50 });
+  });
+
+  it("maps aborted runs to cancelled lifecycle and result status", async () => {
+    const runner = new AbortAwareRunner();
+    const adapter = new ClaudeCodeAdapter({ runner });
+    const handle = await adapter.run({
+      runId: "run-cancel",
+      workstreamId: "workstream-1",
+      role: "build",
+      goal: "Cancel this run.",
+      workspacePath: "/tmp/workspace",
+    });
+
+    await handle.cancel();
+
+    const [events, result] = await Promise.all([
+      collect(handle.events),
+      handle.result,
+    ]);
+
+    expect(runner.requests[0]?.signal?.aborted).toBe(true);
+    expect(result).toMatchObject({
+      status: "cancelled",
+      metadata: {
+        cancelled: true,
+      },
+    });
+    expect(events).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: "lifecycle", status: "started" }),
+        expect.objectContaining({ type: "lifecycle", status: "cancelled" }),
+      ]),
+    );
+    expect(events).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: "error" }),
+      ]),
+    );
+  });
+
+  it("captures text output and maps a non-zero exit to a failed result", async () => {
+    const runner = new FakeRunner([
+      {
+        exitCode: 2,
+        stdout: "partial text result\n",
+        stderr: "Claude failed\n",
+      },
+    ]);
+    const adapter = new ClaudeCodeAdapter({ runner });
+    const handle = await adapter.run({
+      runId: "run-2",
+      workstreamId: "workstream-1",
+      role: "build",
+      goal: "Fail this run.",
+      workspacePath: "/tmp/workspace",
+    });
+
+    const [events, result] = await Promise.all([
+      collect(handle.events),
+      handle.result,
+    ]);
+
+    expect(result).toMatchObject({
+      status: "failed",
+      summary: "partial text result",
+      errorMessage: "Claude failed",
+      metadata: {
+        exitCode: 2,
+        outputFormat: "text",
+      },
+    });
+    expect(events).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "artifact",
+          artifactType: "log",
+          content: "partial text result\n",
+          metadata: { stream: "stdout" },
+        }),
+        expect.objectContaining({
+          type: "artifact",
+          artifactType: "log",
+          content: "Claude failed\n",
+          metadata: { stream: "stderr" },
+        }),
+        expect.objectContaining({
+          type: "error",
+          message: "Claude failed",
+          code: "CLAUDE_EXIT_2",
+        }),
+        expect.objectContaining({ type: "lifecycle", status: "failed" }),
+      ]),
+    );
+  });
+});

--- a/packages/claude-code-adapter/tsconfig.json
+++ b/packages/claude-code-adapter/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "declaration": true,
+    "emitDeclarationOnly": false,
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "dist",
+    "rootDir": "src",
+    "noEmit": false,
+    "types": ["node", "vitest/globals"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["dist", "test"]
+}


### PR DESCRIPTION
## Summary
- Adds the first-party `@mergepilot/claude-code-adapter` workspace package implementing the provider-neutral `AgentAdapter` contract.
- Detects the local `claude` CLI, runs bounded auth/health checks, and starts one-shot print-mode runs in the requested workspace.
- Normalizes stdout/stderr, summaries, failed runs, cancelled runs, and session resume ids into MergePilot agent run events/results.
- Adds safety guards for detect/health timeouts, max-turn caps, output-buffer caps, command-event redaction, and cancellation handling.
- Documents Claude adapter registration and operational safeguards.

## Verification
- [x] `npm run verify`
- [x] Runtime ESM smoke: `node -e "import('@mergepilot/claude-code-adapter').then(m => console.log(Object.keys(m).sort().join(',')))"`
- [x] `git diff --check`
- [x] `npm audit --omit=dev`
- [x] Static scan of added lines for common secret/shell-injection patterns
- [x] Independent pre-commit review passed after blocker fixes

Closes #12
