### PR TITLE
feat: add Codex adapter

### DIFF
--- a/docs/agent-adapters.md
+++ b/docs/agent-adapters.md
@@ -116,6 +116,50 @@ The Claude adapter keeps local CLI calls bounded:
 - command lifecycle events redact the prompt and provider-native resume session id;
 - `defaultMaxTurns`, `metadata.claudeMaxTurns`, and `metadata.maxTurns` are capped at 50.
 
+## Codex Adapter
+
+The OpenAI Codex adapter lives in `packages/codex-adapter` and exports `CodexAdapter` from `@mergepilot/codex-adapter`.
+
+It detects the local `codex` binary with `codex --version`, performs a bounded health check with `codex exec`, and starts one-shot runs in a workspace path with:
+
+```sh
+codex exec --sandbox workspace-write "<task>"
+```
+
+Register it at the application composition boundary:
+
+```ts
+import { createAgentAdapterRegistry } from "@mergepilot/agents";
+import { CodexAdapter } from "@mergepilot/codex-adapter";
+
+const registry = createAgentAdapterRegistry();
+
+registry.register(
+  new CodexAdapter({
+    adapterId: "codex-local",
+    sandbox: "workspace-write",
+    defaultArgs: ["--model", "gpt-5.2"],
+  }),
+);
+```
+
+The adapter joins `AgentRunInput.session.handoff`, `goal`, and `instructions` into the final task prompt and passes it as the last argv item. Command events redact that final prompt before orchestration or UI code sees it. Additional `defaultArgs` are inserted before the task prompt, so callers can configure stable non-secret CLI flags without string concatenation.
+
+Codex process execution is isolated behind an injected runner. The default runner uses `spawn(command, args)` without a shell, streams stdout and stderr chunks as normalized `artifactType: "log"` events, and maps process cancellation to a `cancelled` result. The runner boundary also supports future PTY supervision: custom runners can emit stdout, stderr, and `waiting-for-input` events while still returning a final bounded result.
+
+Waiting-for-input states are surfaced as lifecycle `running` events with the message `Codex is waiting for input.`. This keeps the provider-neutral contract unchanged while giving workstream UI enough signal to pause, request operator action, or mark a run as blocked.
+
+The Codex adapter keeps local CLI calls bounded:
+
+- detection runs use `detectTimeoutMs`, defaulting to 5 seconds;
+- health checks use `healthTimeoutMs`, defaulting to 30 seconds;
+- health details report whether the CLI is installed and whether auth appears authenticated, unauthenticated, or unknown;
+- run output buffers are capped by `maxBufferBytes`, defaulting to 1 MiB per stream;
+- post-run diff evidence collection uses `diffTimeoutMs`, defaulting to 5 seconds;
+- run cancellation aborts the active process and resolves the run as `cancelled`;
+- command lifecycle events redact the task prompt;
+- after a successful real CLI run, the runner collects bounded `git diff --no-ext-diff --no-color` evidence in the workspace and emits it as a `diff` artifact when available; detection and health checks do not collect diffs.
+
 ## Session Continuation
 
 Adapters that can resume provider-native sessions should declare `capabilities.sessionResume`. Orchestration passes continuation context through `AgentRunInput.session`:

--- a/package-lock.json
+++ b/package-lock.json
@@ -854,6 +854,10 @@
       "resolved": "packages/claude-code-adapter",
       "link": true
     },
+    "node_modules/@mergepilot/codex-adapter": {
+      "resolved": "packages/codex-adapter",
+      "link": true
+    },
     "node_modules/@mergepilot/desktop": {
       "resolved": "apps/desktop",
       "link": true
@@ -3806,6 +3810,16 @@
     },
     "packages/claude-code-adapter": {
       "name": "@mergepilot/claude-code-adapter",
+      "version": "0.0.0",
+      "dependencies": {
+        "@mergepilot/agents": "0.0.0"
+      },
+      "devDependencies": {
+        "vitest": "^3.1.2"
+      }
+    },
+    "packages/codex-adapter": {
+      "name": "@mergepilot/codex-adapter",
       "version": "0.0.0",
       "dependencies": {
         "@mergepilot/agents": "0.0.0"

--- a/packages/codex-adapter/package.json
+++ b/packages/codex-adapter/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@mergepilot/codex-adapter",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "vitest run"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "dependencies": {
+    "@mergepilot/agents": "0.0.0"
+  },
+  "devDependencies": {
+    "vitest": "^3.1.2"
+  }
+}

--- a/packages/codex-adapter/src/index.ts
+++ b/packages/codex-adapter/src/index.ts
@@ -1,0 +1,642 @@
+import type {
+  AgentAdapter,
+  AgentAdapterMetadata,
+  AgentProviderDetectionInput,
+  AgentProviderDetectionResult,
+  AgentProviderHealthInput,
+  AgentProviderHealthResult,
+  AgentRunArtifactEvent,
+  AgentRunEvent,
+  AgentRunHandle,
+  AgentRunInput,
+  AgentRunLifecycleStatus,
+  AgentRunResult,
+} from "@mergepilot/agents";
+import {
+  CodexCliEvent,
+  CodexCliRunner,
+  CodexCliRunRequest,
+  CodexCliRunResult,
+  SpawnCodexCliRunner,
+} from "./process-runner.js";
+
+export type {
+  CodexCliEvent,
+  CodexCliRunner,
+  CodexCliRunRequest,
+  CodexCliRunResult,
+} from "./process-runner.js";
+
+export interface CodexAdapterOptions {
+  adapterId?: string;
+  executable?: string;
+  sandbox?: string;
+  defaultArgs?: readonly string[];
+  detectTimeoutMs?: number;
+  healthTimeoutMs?: number;
+  diffTimeoutMs?: number;
+  maxBufferBytes?: number;
+  runner?: CodexCliRunner;
+}
+
+const PROVIDER_ID = "codex";
+const DEFAULT_SANDBOX = "workspace-write";
+const DEFAULT_DETECT_TIMEOUT_MS = 5_000;
+const DEFAULT_HEALTH_TIMEOUT_MS = 30_000;
+const DEFAULT_DIFF_TIMEOUT_MS = 5_000;
+const DEFAULT_MAX_BUFFER_BYTES = 1024 * 1024;
+const REDACTED = "[redacted]";
+const SENSITIVE_ARG_NAMES = new Set([
+  "--api-key",
+  "--auth-token",
+  "--password",
+  "--token",
+]);
+
+export class CodexAdapter implements AgentAdapter {
+  readonly #executable: string;
+  readonly #sandbox: string;
+  readonly #defaultArgs: readonly string[];
+  readonly #detectTimeoutMs: number;
+  readonly #healthTimeoutMs: number;
+  readonly #diffTimeoutMs: number;
+  readonly #maxBufferBytes: number;
+  readonly #runner: CodexCliRunner;
+
+  readonly metadata: AgentAdapterMetadata;
+
+  constructor(options: CodexAdapterOptions = {}) {
+    this.#executable = options.executable ?? "codex";
+    this.#sandbox = normalizeString(options.sandbox, DEFAULT_SANDBOX);
+    this.#defaultArgs = options.defaultArgs ?? [];
+    this.#detectTimeoutMs = normalizePositiveInteger(
+      options.detectTimeoutMs,
+      DEFAULT_DETECT_TIMEOUT_MS,
+    );
+    this.#healthTimeoutMs = normalizePositiveInteger(
+      options.healthTimeoutMs,
+      DEFAULT_HEALTH_TIMEOUT_MS,
+    );
+    this.#diffTimeoutMs = normalizePositiveInteger(
+      options.diffTimeoutMs,
+      DEFAULT_DIFF_TIMEOUT_MS,
+    );
+    this.#maxBufferBytes = normalizePositiveInteger(
+      options.maxBufferBytes,
+      DEFAULT_MAX_BUFFER_BYTES,
+    );
+    this.#runner = options.runner ?? new SpawnCodexCliRunner();
+    this.metadata = {
+      adapterId: options.adapterId,
+      providerId: PROVIDER_ID,
+      displayName: "OpenAI Codex",
+      capabilities: {
+        streamingEvents: true,
+        cancellation: true,
+        structuredResults: false,
+        sessionResume: false,
+      },
+      labels: ["local-cli", "first-party"],
+    };
+  }
+
+  async detect(
+    input: AgentProviderDetectionInput = {},
+  ): Promise<AgentProviderDetectionResult> {
+    const checkedAt = new Date().toISOString();
+    const result = await this.#runCli({
+      command: this.#executable,
+      args: ["--version"],
+      cwd: input.cwd,
+      env: input.env,
+      timeoutMs: this.#detectTimeoutMs,
+    });
+
+    if (result.timedOut) {
+      return {
+        providerId: PROVIDER_ID,
+        status: "unknown",
+        checkedAt,
+        message: `Codex CLI detection timed out after ${this.#detectTimeoutMs}ms.`,
+      };
+    }
+
+    if (isMissingBinary(result)) {
+      return {
+        providerId: PROVIDER_ID,
+        status: "unavailable",
+        checkedAt,
+        message: `Codex CLI '${this.#executable}' was not found.`,
+      };
+    }
+
+    if (result.exitCode === 0) {
+      const version = firstLine(result.stdout) ?? firstLine(result.stderr);
+      return {
+        providerId: PROVIDER_ID,
+        status: "available",
+        checkedAt,
+        message: version
+          ? `Codex CLI is installed: ${version}.`
+          : "Codex CLI is installed.",
+        version,
+        executablePath: this.#executable,
+      };
+    }
+
+    return {
+      providerId: PROVIDER_ID,
+      status: "unavailable",
+      checkedAt,
+      message:
+        firstLine(result.stderr) ??
+        firstLine(result.stdout) ??
+        `Codex CLI exited with code ${result.exitCode}.`,
+    };
+  }
+
+  async health(
+    input: AgentProviderHealthInput = {},
+  ): Promise<AgentProviderHealthResult> {
+    const detected = await this.detect(input);
+    const checkedAt = new Date().toISOString();
+
+    if (detected.status !== "available") {
+      return {
+        providerId: PROVIDER_ID,
+        status: detected.status === "unknown" ? "unknown" : "unavailable",
+        checkedAt,
+        message: detected.message,
+        details: { detectionStatus: detected.status },
+      };
+    }
+
+    const result = await this.#runCli({
+      command: this.#executable,
+      args: ["exec", "--sandbox", "read-only", "Reply with OK only."],
+      cwd: input.cwd,
+      env: input.env,
+      timeoutMs: this.#healthTimeoutMs,
+    });
+
+    if (result.timedOut) {
+      return {
+        providerId: PROVIDER_ID,
+        status: "unknown",
+        checkedAt,
+        message: `Codex CLI health check timed out after ${this.#healthTimeoutMs}ms.`,
+        details: {
+          reason: "timeout",
+          version: detected.version,
+        },
+      };
+    }
+
+    if (result.exitCode === 0) {
+      return {
+        providerId: PROVIDER_ID,
+        status: "healthy",
+        checkedAt,
+        message: "Codex CLI is installed and accepted a bounded exec run.",
+        details: {
+          installed: true,
+          authStatus: "authenticated",
+          version: detected.version,
+        },
+      };
+    }
+
+    const message =
+      firstLine(result.stderr) ??
+      firstLine(result.stdout) ??
+      `Codex CLI health check exited with code ${result.exitCode}.`;
+
+    return {
+      providerId: PROVIDER_ID,
+      status: "degraded",
+      checkedAt,
+      message,
+      details: {
+        reason: looksUnauthenticated(message) ? "unauthenticated" : "unavailable",
+        installed: true,
+        authStatus: looksUnauthenticated(message) ? "unauthenticated" : "unknown",
+        exitCode: result.exitCode,
+        version: detected.version,
+      },
+    };
+  }
+
+  async run(input: AgentRunInput): Promise<AgentRunHandle> {
+    const abortController = new AbortController();
+    const eventStream = createEventStream<AgentRunEvent>();
+    const execution = this.#executeRun(input, abortController.signal, eventStream.push);
+
+    execution
+      .then(({ result }) => eventStream.close(result))
+      .catch((error: unknown) => eventStream.fail(error));
+
+    return {
+      runId: input.runId,
+      providerId: PROVIDER_ID,
+      adapterId: this.metadata.adapterId,
+      events: eventStream.iterable,
+      result: execution.then(({ result }) => result),
+      cancel: async () => {
+        abortController.abort();
+      },
+    };
+  }
+
+  async #executeRun(
+    input: AgentRunInput,
+    signal: AbortSignal,
+    emit: (event: AgentRunEvent) => void,
+  ): Promise<{ result: AgentRunResult }> {
+    const startedAt = new Date().toISOString();
+    const artifacts: AgentRunArtifactEvent[] = [];
+    const prompt = buildPrompt(input);
+    const args = [
+      "exec",
+      "--sandbox",
+      this.#sandbox,
+      ...this.#defaultArgs,
+      prompt,
+    ];
+
+    emit(lifecycleEvent(input.runId, startedAt, "started", "Codex run started."));
+    emit({
+      type: "command",
+      runId: input.runId,
+      providerId: PROVIDER_ID,
+      timestamp: startedAt,
+      command: formatCommand(this.#executable, args),
+      cwd: input.workspacePath,
+    });
+
+    const emittedProcessStreams = new Set<string>();
+    const cliResult = await this.#runCli({
+      command: this.#executable,
+      args,
+      cwd: input.workspacePath,
+      env: input.env,
+      signal,
+      collectDiff: true,
+      diffTimeoutMs: this.#diffTimeoutMs,
+      onEvent: (event) => {
+        const normalized = normalizeProcessEvent(input.runId, event);
+
+        if (normalized.type === "artifact") {
+          artifacts.push(normalized);
+          const stream = normalized.metadata?.stream;
+          if (typeof stream === "string") {
+            emittedProcessStreams.add(stream);
+          }
+        }
+
+        emit(normalized);
+      },
+    });
+    const completedAt = new Date().toISOString();
+    const cancelled = signal.aborted || isAbortedResult(cliResult);
+
+    if (cliResult.stdout.trim()) {
+      const event = artifactEvent(input.runId, completedAt, "log", {
+        content: cliResult.stdout,
+        metadata: { stream: "stdout", source: "final" },
+      });
+      if (!emittedProcessStreams.has("stdout")) {
+        artifacts.push(event);
+        emit(event);
+      }
+    }
+
+    if (cliResult.stderr.trim()) {
+      const event = artifactEvent(input.runId, completedAt, "log", {
+        content: cliResult.stderr,
+        metadata: { stream: "stderr", source: "final" },
+      });
+      if (!emittedProcessStreams.has("stderr")) {
+        artifacts.push(event);
+        emit(event);
+      }
+    }
+
+    const summary = fallbackSummary(cliResult);
+
+    if (summary) {
+      emit({
+        type: "message",
+        runId: input.runId,
+        providerId: PROVIDER_ID,
+        timestamp: completedAt,
+        role: "agent",
+        content: summary,
+      });
+      const event = artifactEvent(input.runId, completedAt, "summary", {
+        content: summary,
+      });
+      artifacts.push(event);
+      emit(event);
+    }
+
+    if (cliResult.diff?.trim()) {
+      const event = artifactEvent(input.runId, completedAt, "diff", {
+        content: cliResult.diff,
+        metadata: { source: "git-diff" },
+      });
+      artifacts.push(event);
+      emit(event);
+    }
+
+    const status = cancelled
+      ? "cancelled"
+      : cliResult.exitCode === 0
+        ? "completed"
+        : "failed";
+    const errorMessage =
+      status === "failed"
+        ? firstLine(cliResult.stderr) ??
+          firstLine(cliResult.stdout) ??
+          `Codex CLI exited with code ${cliResult.exitCode}.`
+        : undefined;
+
+    if (errorMessage) {
+      emit({
+        type: "error",
+        runId: input.runId,
+        providerId: PROVIDER_ID,
+        timestamp: completedAt,
+        message: errorMessage,
+        code:
+          typeof cliResult.exitCode === "number"
+            ? `CODEX_EXIT_${cliResult.exitCode}`
+            : "CODEX_PROCESS_ERROR",
+        recoverable: false,
+      });
+    }
+
+    emit(
+      lifecycleEvent(
+        input.runId,
+        completedAt,
+        status,
+        status === "completed"
+          ? "Codex run completed."
+          : status === "cancelled"
+            ? "Codex run cancelled."
+            : "Codex run failed.",
+      ),
+    );
+
+    return {
+      result: {
+        runId: input.runId,
+        providerId: PROVIDER_ID,
+        adapterId: this.metadata.adapterId,
+        status,
+        summary,
+        errorMessage,
+        startedAt,
+        completedAt,
+        artifacts,
+        metadata: {
+          exitCode: cliResult.exitCode,
+          sandbox: this.#sandbox,
+          cancelled,
+          stdoutTruncated: cliResult.stdoutTruncated || undefined,
+          stderrTruncated: cliResult.stderrTruncated || undefined,
+          diffTruncated: cliResult.diffTruncated || undefined,
+          diffTimedOut: cliResult.diffTimedOut || undefined,
+        },
+      },
+    };
+  }
+
+  async #runCli(request: CodexCliRunRequest): Promise<CodexCliRunResult> {
+    try {
+      return await this.#runner.run({
+        maxBufferBytes: this.#maxBufferBytes,
+        ...request,
+      });
+    } catch (error) {
+      return {
+        exitCode: null,
+        stdout: "",
+        stderr: error instanceof Error ? error.message : String(error),
+        error,
+      };
+    }
+  }
+}
+
+function lifecycleEvent(
+  runId: string,
+  timestamp: string,
+  status: AgentRunLifecycleStatus,
+  message: string,
+): AgentRunEvent {
+  return {
+    type: "lifecycle",
+    runId,
+    providerId: PROVIDER_ID,
+    timestamp,
+    status,
+    message,
+  };
+}
+
+function artifactEvent(
+  runId: string,
+  timestamp: string,
+  artifactType: AgentRunArtifactEvent["artifactType"],
+  event: Pick<AgentRunArtifactEvent, "content" | "metadata">,
+): AgentRunArtifactEvent {
+  return {
+    type: "artifact",
+    runId,
+    providerId: PROVIDER_ID,
+    timestamp,
+    artifactType,
+    ...event,
+  };
+}
+
+function normalizeProcessEvent(runId: string, event: CodexCliEvent): AgentRunEvent {
+  const timestamp = new Date().toISOString();
+
+  if (event.type === "waiting-for-input") {
+    return lifecycleEvent(runId, timestamp, "running", "Codex is waiting for input.");
+  }
+
+  return artifactEvent(runId, timestamp, "log", {
+    content: event.data,
+    metadata: {
+      stream: event.type,
+      source: "process",
+    },
+  });
+}
+
+function buildPrompt(input: AgentRunInput): string {
+  return [input.session?.handoff, input.goal, input.instructions]
+    .filter((value): value is string => Boolean(value?.trim()))
+    .join("\n\n");
+}
+
+function normalizePositiveInteger(value: unknown, fallback: number): number {
+  return typeof value === "number" && Number.isInteger(value) && value > 0
+    ? value
+    : fallback;
+}
+
+function normalizeString(value: unknown, fallback: string): string {
+  return typeof value === "string" && value.trim() ? value : fallback;
+}
+
+function fallbackSummary(result: CodexCliRunResult): string | undefined {
+  return firstLine(result.stdout) ?? firstLine(result.stderr);
+}
+
+function firstLine(value: string): string | undefined {
+  const line = value
+    .split(/\r?\n/)
+    .map((entry) => entry.trim())
+    .find(Boolean);
+
+  return line || undefined;
+}
+
+function formatCommand(command: string, args: readonly string[]): string {
+  return [command, ...redactArgs(args)].map(formatShellToken).join(" ");
+}
+
+function redactArgs(args: readonly string[]): string[] {
+  if (args.length === 0) {
+    return [];
+  }
+
+  const redacted: string[] = [];
+  let redactNext = false;
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index] ?? "";
+
+    if (index === args.length - 1 || redactNext) {
+      redacted.push(REDACTED);
+      redactNext = false;
+      continue;
+    }
+
+    const [name, value] = arg.split("=", 2);
+    if (SENSITIVE_ARG_NAMES.has(name)) {
+      redacted.push(value === undefined ? arg : `${name}=${REDACTED}`);
+      redactNext = value === undefined;
+      continue;
+    }
+
+    redacted.push(arg);
+  }
+
+  return redacted;
+}
+
+function formatShellToken(value: string): string {
+  return /^[A-Za-z0-9_./:=+-]+$/.test(value)
+    ? value
+    : JSON.stringify(value);
+}
+
+
+function isMissingBinary(result: CodexCliRunResult): boolean {
+  const error = result.error;
+
+  return (
+    hasErrorCode(error, "ENOENT") ||
+    /\bENOENT\b/i.test(result.stderr) ||
+    /\bnot found\b/i.test(result.stderr)
+  );
+}
+
+function hasErrorCode(error: unknown, code: string): boolean {
+  return isRecord(error) && error.code === code;
+}
+
+function isAbortedResult(result: CodexCliRunResult): boolean {
+  return (
+    result.aborted === true ||
+    result.signal === "SIGTERM" ||
+    result.signal === "SIGINT" ||
+    (isRecord(result.error) && result.error.name === "AbortError")
+  );
+}
+
+function looksUnauthenticated(value: string): boolean {
+  return /\b(auth|authenticate|authenticated|login|log in|token|api key)\b/i.test(value);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function createEventStream<T>(): {
+  iterable: AsyncIterable<T>;
+  push: (value: T) => void;
+  close: (value?: unknown) => void;
+  fail: (error: unknown) => void;
+} {
+  const values: T[] = [];
+  const waiters: Array<{
+    resolve: (result: IteratorResult<T>) => void;
+    reject: (error: unknown) => void;
+  }> = [];
+  let closed = false;
+  let failed: unknown;
+
+  const next = (): Promise<IteratorResult<T>> => {
+    if (values.length > 0) {
+      return Promise.resolve({ done: false, value: values.shift() as T });
+    }
+
+    if (failed) {
+      return Promise.reject(failed);
+    }
+
+    if (closed) {
+      return Promise.resolve({ done: true, value: undefined });
+    }
+
+    return new Promise((resolve, reject) => {
+      waiters.push({ resolve, reject });
+    });
+  };
+
+  return {
+    iterable: {
+      [Symbol.asyncIterator]() {
+        return { next };
+      },
+    },
+    push: (value) => {
+      const waiter = waiters.shift();
+
+      if (waiter) {
+        waiter.resolve({ done: false, value });
+        return;
+      }
+
+      values.push(value);
+    },
+    close: () => {
+      closed = true;
+      for (const waiter of waiters.splice(0)) {
+        waiter.resolve({ done: true, value: undefined });
+      }
+    },
+    fail: (error) => {
+      failed = error;
+      for (const waiter of waiters.splice(0)) {
+        waiter.reject(error);
+      }
+    },
+  };
+}

--- a/packages/codex-adapter/src/process-runner.ts
+++ b/packages/codex-adapter/src/process-runner.ts
@@ -1,0 +1,271 @@
+import { spawn } from "node:child_process";
+
+export type CodexCliEvent =
+  | { type: "stdout"; data: string }
+  | { type: "stderr"; data: string }
+  | { type: "waiting-for-input"; message?: string; metadata?: Readonly<Record<string, unknown>> };
+
+export interface CodexCliRunRequest {
+  command: string;
+  args: readonly string[];
+  cwd?: string;
+  env?: Readonly<Record<string, string | undefined>>;
+  signal?: AbortSignal;
+  timeoutMs?: number;
+  maxBufferBytes?: number;
+  collectDiff?: boolean;
+  diffTimeoutMs?: number;
+  onEvent?: (event: CodexCliEvent) => void;
+}
+
+export interface CodexCliRunResult {
+  exitCode: number | null;
+  stdout: string;
+  stderr: string;
+  diff?: string;
+  error?: unknown;
+  signal?: NodeJS.Signals | null;
+  aborted?: boolean;
+  timedOut?: boolean;
+  stdoutTruncated?: boolean;
+  stderrTruncated?: boolean;
+  diffTruncated?: boolean;
+  diffTimedOut?: boolean;
+  events?: readonly CodexCliEvent[];
+}
+
+export interface CodexCliRunner {
+  run(request: CodexCliRunRequest): Promise<CodexCliRunResult>;
+}
+
+const DEFAULT_MAX_BUFFER_BYTES = 1024 * 1024;
+
+export class SpawnCodexCliRunner implements CodexCliRunner {
+  run(request: CodexCliRunRequest): Promise<CodexCliRunResult> {
+    return new Promise((resolve) => {
+      const controller = new AbortController();
+      const abort = () => controller.abort();
+      const timeoutMs = normalizeTimeoutMs(request.timeoutMs);
+      let timedOut = false;
+      const timeout = timeoutMs
+        ? setTimeout(() => {
+            timedOut = true;
+            controller.abort();
+          }, timeoutMs)
+        : undefined;
+
+      if (request.signal?.aborted) {
+        controller.abort();
+      } else {
+        request.signal?.addEventListener("abort", abort, { once: true });
+      }
+
+      const child = spawn(request.command, request.args, {
+        cwd: request.cwd,
+        env: mergeEnv(request.env),
+        signal: controller.signal,
+        windowsHide: true,
+      });
+      const stdout: Buffer[] = [];
+      const stderr: Buffer[] = [];
+      const maxBufferBytes = normalizeMaxBufferBytes(request.maxBufferBytes);
+      let stdoutBytes = 0;
+      let stderrBytes = 0;
+      let stdoutTruncated = false;
+      let stderrTruncated = false;
+      let spawnError: unknown;
+
+      child.stdout.on("data", (chunk: Buffer) => {
+        const accepted = boundedChunk(chunk, stdoutBytes, maxBufferBytes);
+        const result = appendBoundedBuffer(stdout, stdoutBytes, chunk, maxBufferBytes);
+        stdoutBytes = result.bytes;
+        stdoutTruncated ||= result.truncated;
+        if (accepted.byteLength > 0) {
+          request.onEvent?.({ type: "stdout", data: accepted.toString("utf8") });
+        }
+      });
+      child.stderr.on("data", (chunk: Buffer) => {
+        const accepted = boundedChunk(chunk, stderrBytes, maxBufferBytes);
+        const text = accepted.toString("utf8");
+        const result = appendBoundedBuffer(stderr, stderrBytes, chunk, maxBufferBytes);
+        stderrBytes = result.bytes;
+        stderrTruncated ||= result.truncated;
+        if (accepted.byteLength > 0) {
+          request.onEvent?.({ type: "stderr", data: text });
+        }
+
+        if (text && looksLikeWaitingForInput(text)) {
+          request.onEvent?.({
+            type: "waiting-for-input",
+            message: "Codex is waiting for input.",
+            metadata: { source: "stderr" },
+          });
+        }
+      });
+      child.on("error", (error) => {
+        spawnError = error;
+      });
+      child.on("close", async (exitCode, signal) => {
+        if (timeout) {
+          clearTimeout(timeout);
+        }
+        request.signal?.removeEventListener("abort", abort);
+        const diffResult =
+          exitCode === 0 && request.cwd && request.collectDiff
+            ? await collectGitDiff({
+                cwd: request.cwd,
+                maxBufferBytes,
+                timeoutMs: request.diffTimeoutMs ?? request.timeoutMs,
+                signal: request.signal,
+              })
+            : undefined;
+        resolve({
+          exitCode,
+          stdout: Buffer.concat(stdout).toString("utf8"),
+          stderr: Buffer.concat(stderr).toString("utf8"),
+          diff: diffResult?.content,
+          error: spawnError,
+          signal,
+          aborted: controller.signal.aborted,
+          timedOut,
+          stdoutTruncated,
+          stderrTruncated,
+          diffTruncated: diffResult?.truncated,
+          diffTimedOut: diffResult?.timedOut,
+        });
+      });
+    });
+  }
+}
+
+function boundedChunk(
+  chunk: Buffer,
+  existingBytes: number,
+  maxBufferBytes: number,
+): Buffer {
+  const remainingBytes = maxBufferBytes - existingBytes;
+
+  if (remainingBytes <= 0) {
+    return Buffer.alloc(0);
+  }
+
+  return chunk.byteLength <= remainingBytes
+    ? chunk
+    : chunk.subarray(0, remainingBytes);
+}
+
+function appendBoundedBuffer(
+  chunks: Buffer[],
+  existingBytes: number,
+  chunk: Buffer,
+  maxBufferBytes: number,
+): { bytes: number; truncated: boolean } {
+  const remainingBytes = maxBufferBytes - existingBytes;
+
+  if (remainingBytes <= 0) {
+    return { bytes: existingBytes, truncated: true };
+  }
+
+  if (chunk.byteLength <= remainingBytes) {
+    chunks.push(chunk);
+    return { bytes: existingBytes + chunk.byteLength, truncated: false };
+  }
+
+  chunks.push(chunk.subarray(0, remainingBytes));
+  return { bytes: maxBufferBytes, truncated: true };
+}
+
+function normalizeTimeoutMs(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) && value > 0
+    ? value
+    : undefined;
+}
+
+function normalizeMaxBufferBytes(value: unknown): number {
+  return typeof value === "number" && Number.isInteger(value) && value > 0
+    ? value
+    : DEFAULT_MAX_BUFFER_BYTES;
+}
+
+function mergeEnv(
+  env?: Readonly<Record<string, string | undefined>>,
+): NodeJS.ProcessEnv | undefined {
+  return env ? { ...process.env, ...env } : undefined;
+}
+
+function looksLikeWaitingForInput(value: string): boolean {
+  return /\b(waiting for|approval required|press enter|confirm|continue\?)\b/i.test(value);
+}
+
+interface CollectGitDiffInput {
+  cwd: string;
+  maxBufferBytes: number;
+  timeoutMs?: number;
+  signal?: AbortSignal;
+}
+
+interface CollectGitDiffResult {
+  content?: string;
+  truncated?: boolean;
+  timedOut?: boolean;
+}
+
+function collectGitDiff(input: CollectGitDiffInput): Promise<CollectGitDiffResult | undefined> {
+  return new Promise((resolve) => {
+    const controller = new AbortController();
+    const abort = () => controller.abort();
+    const timeoutMs = normalizeTimeoutMs(input.timeoutMs);
+    let timedOut = false;
+    const timeout = timeoutMs
+      ? setTimeout(() => {
+          timedOut = true;
+          controller.abort();
+        }, timeoutMs)
+      : undefined;
+
+    if (input.signal?.aborted) {
+      controller.abort();
+    } else {
+      input.signal?.addEventListener("abort", abort, { once: true });
+    }
+
+    const child = spawn("git", ["diff", "--no-ext-diff", "--no-color"], {
+      cwd: input.cwd,
+      signal: controller.signal,
+      windowsHide: true,
+    });
+    const stdout: Buffer[] = [];
+    let stdoutBytes = 0;
+    let truncated = false;
+    let spawnError: unknown;
+
+    child.stdout.on("data", (chunk: Buffer) => {
+      const result = appendBoundedBuffer(stdout, stdoutBytes, chunk, input.maxBufferBytes);
+      stdoutBytes = result.bytes;
+      truncated ||= result.truncated;
+    });
+    child.stderr.resume();
+    child.on("error", (error) => {
+      spawnError = error;
+    });
+    child.on("close", (exitCode) => {
+      if (timeout) {
+        clearTimeout(timeout);
+      }
+      input.signal?.removeEventListener("abort", abort);
+
+      if (timedOut) {
+        resolve({ timedOut: true });
+        return;
+      }
+
+      if (spawnError || exitCode !== 0 || controller.signal.aborted) {
+        resolve(undefined);
+        return;
+      }
+
+      const diff = Buffer.concat(stdout).toString("utf8");
+      resolve(diff.trim() ? { content: diff, truncated } : undefined);
+    });
+  });
+}

--- a/packages/codex-adapter/test/codex-adapter.test.ts
+++ b/packages/codex-adapter/test/codex-adapter.test.ts
@@ -1,0 +1,385 @@
+import { describe, expect, it } from "vitest";
+import {
+  CodexAdapter,
+  CodexCliEvent,
+  CodexCliRunner,
+  CodexCliRunRequest,
+  CodexCliRunResult,
+} from "../src/index.js";
+
+class FakeRunner implements CodexCliRunner {
+  readonly requests: CodexCliRunRequest[] = [];
+  #results: CodexCliRunResult[];
+
+  constructor(results: CodexCliRunResult[]) {
+    this.#results = [...results];
+  }
+
+  async run(request: CodexCliRunRequest): Promise<CodexCliRunResult> {
+    this.requests.push(request);
+    const result = this.#results.shift();
+
+    if (!result) {
+      throw new Error("Unexpected fake Codex CLI request.");
+    }
+
+    for (const event of result.events ?? []) {
+      request.onEvent?.(event);
+    }
+
+    return result;
+  }
+}
+
+class AbortAwareRunner implements CodexCliRunner {
+  readonly requests: CodexCliRunRequest[] = [];
+
+  run(request: CodexCliRunRequest): Promise<CodexCliRunResult> {
+    this.requests.push(request);
+
+    return new Promise((resolve) => {
+      request.signal?.addEventListener(
+        "abort",
+        () => {
+          resolve({
+            exitCode: null,
+            stdout: "",
+            stderr: "",
+            error: Object.assign(new Error("The operation was aborted."), {
+              name: "AbortError",
+            }),
+            aborted: true,
+          });
+        },
+        { once: true },
+      );
+    });
+  }
+}
+
+const success = (stdout = "", extra: Partial<CodexCliRunResult> = {}): CodexCliRunResult => ({
+  exitCode: 0,
+  stdout,
+  stderr: "",
+  ...extra,
+});
+
+const failure = (stderr: string, exitCode = 1): CodexCliRunResult => ({
+  exitCode,
+  stdout: "",
+  stderr,
+});
+
+async function collect<T>(iterable: AsyncIterable<T>): Promise<T[]> {
+  const values: T[] = [];
+
+  for await (const value of iterable) {
+    values.push(value);
+  }
+
+  return values;
+}
+
+describe("CodexAdapter", () => {
+  it("reports detection and healthy auth status", async () => {
+    const runner = new FakeRunner([
+      success("codex-cli 1.2.3\n"),
+      success("codex-cli 1.2.3\n"),
+      success("OK\n"),
+    ]);
+    const adapter = new CodexAdapter({ runner });
+
+    await expect(adapter.detect()).resolves.toMatchObject({
+      providerId: "codex",
+      status: "available",
+      version: "codex-cli 1.2.3",
+      executablePath: "codex",
+    });
+
+    await expect(adapter.health({ cwd: "/tmp/repo" })).resolves.toMatchObject({
+      providerId: "codex",
+      status: "healthy",
+      details: { version: "codex-cli 1.2.3" },
+    });
+
+    expect(runner.requests[0]).toMatchObject({
+      command: "codex",
+      args: ["--version"],
+      timeoutMs: 5000,
+    });
+    expect(runner.requests[0]?.collectDiff).toBeUndefined();
+    expect(runner.requests[2]).toMatchObject({
+      cwd: "/tmp/repo",
+      args: ["exec", "--sandbox", "read-only", "Reply with OK only."],
+      timeoutMs: 30000,
+    });
+    expect(runner.requests[2]?.collectDiff).toBeUndefined();
+  });
+
+  it("bounds detection and health checks with configurable timeouts", async () => {
+    const runner = new FakeRunner([
+      { exitCode: null, stdout: "", stderr: "", timedOut: true },
+      success("codex-cli 1.2.3\n"),
+      { exitCode: null, stdout: "", stderr: "", timedOut: true },
+    ]);
+    const adapter = new CodexAdapter({
+      runner,
+      detectTimeoutMs: 123,
+      healthTimeoutMs: 456,
+    });
+
+    await expect(adapter.detect()).resolves.toMatchObject({
+      status: "unknown",
+      message: expect.stringContaining("123ms"),
+    });
+    await expect(adapter.health()).resolves.toMatchObject({
+      status: "unknown",
+      message: expect.stringContaining("456ms"),
+      details: { reason: "timeout" },
+    });
+
+    expect(runner.requests[0]).toMatchObject({ args: ["--version"], timeoutMs: 123 });
+    expect(runner.requests[1]).toMatchObject({ args: ["--version"], timeoutMs: 123 });
+    expect(runner.requests[2]).toMatchObject({ timeoutMs: 456 });
+  });
+
+  it("distinguishes missing binary and unauthenticated health", async () => {
+    const missing = new FakeRunner([
+      {
+        exitCode: null,
+        stdout: "",
+        stderr: "",
+        error: Object.assign(new Error("spawn ENOENT"), { code: "ENOENT" }),
+      },
+    ]);
+    const unauthenticated = new FakeRunner([
+      success("codex-cli 1.2.3\n"),
+      failure("Not authenticated. Run codex login.\n"),
+    ]);
+
+    await expect(new CodexAdapter({ runner: missing }).detect()).resolves.toMatchObject({
+      status: "unavailable",
+      message: expect.stringMatching(/not found/i),
+    });
+
+    await expect(new CodexAdapter({ runner: unauthenticated }).health()).resolves.toMatchObject({
+      status: "degraded",
+      details: { reason: "unauthenticated" },
+    });
+  });
+
+  it("runs codex exec in the workspace and normalizes process events and diff evidence", async () => {
+    const emitted: CodexCliEvent[] = [
+      { type: "stdout", data: "Analyzing repo\n" },
+      { type: "waiting-for-input", message: "Codex is waiting for approval." },
+      { type: "stderr", data: "warning: tool approval required\n" },
+    ];
+    const runner = new FakeRunner([
+      success("Implemented the task.\n", {
+        stderr: "warning: tool approval required\n",
+        events: emitted,
+        diff: "diff --git a/a.ts b/a.ts\n+const a = 1;\n",
+        diffTruncated: true,
+      }),
+    ]);
+    const adapter = new CodexAdapter({
+      adapterId: "codex-local",
+      runner,
+      defaultArgs: ["--model", "gpt-5.2"],
+    });
+
+    const handle = await adapter.run({
+      runId: "run-1",
+      workstreamId: "workstream-1",
+      role: "build",
+      goal: "Implement issue 13.",
+      workspacePath: "/tmp/workspace",
+      instructions: "Keep changes focused.",
+    });
+
+    const [events, result] = await Promise.all([
+      collect(handle.events),
+      handle.result,
+    ]);
+
+    expect(runner.requests[0]).toMatchObject({
+      command: "codex",
+      cwd: "/tmp/workspace",
+      args: [
+        "exec",
+        "--sandbox",
+        "workspace-write",
+        "--model",
+        "gpt-5.2",
+        "Implement issue 13.\n\nKeep changes focused.",
+      ],
+      collectDiff: true,
+      diffTimeoutMs: 5000,
+    });
+    expect(result).toMatchObject({
+      runId: "run-1",
+      providerId: "codex",
+      adapterId: "codex-local",
+      status: "completed",
+      summary: "Implemented the task.",
+      metadata: {
+        exitCode: 0,
+        sandbox: "workspace-write",
+        cancelled: false,
+        diffTruncated: true,
+      },
+    });
+    expect(events).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: "lifecycle", status: "started" }),
+        expect.objectContaining({
+          type: "command",
+          cwd: "/tmp/workspace",
+          command:
+            'codex exec --sandbox workspace-write --model gpt-5.2 "[redacted]"',
+        }),
+        expect.objectContaining({
+          type: "artifact",
+          artifactType: "log",
+          content: "Analyzing repo\n",
+          metadata: { stream: "stdout", source: "process" },
+        }),
+        expect.objectContaining({
+          type: "lifecycle",
+          status: "running",
+          message: "Codex is waiting for input.",
+        }),
+        expect.objectContaining({
+          type: "artifact",
+          artifactType: "diff",
+          content: "diff --git a/a.ts b/a.ts\n+const a = 1;\n",
+        }),
+        expect.objectContaining({ type: "lifecycle", status: "completed" }),
+      ]),
+    );
+
+    const commandEvent = events.find((event) => event.type === "command");
+    expect(commandEvent).not.toMatchObject({
+      command: expect.stringContaining("Implement issue 13."),
+    });
+  });
+
+  it("maps aborted runs to cancelled lifecycle and result status", async () => {
+    const runner = new AbortAwareRunner();
+    const adapter = new CodexAdapter({ runner });
+    const handle = await adapter.run({
+      runId: "run-cancel",
+      workstreamId: "workstream-1",
+      role: "build",
+      goal: "Cancel this run.",
+      workspacePath: "/tmp/workspace",
+    });
+
+    await handle.cancel();
+
+    const [events, result] = await Promise.all([
+      collect(handle.events),
+      handle.result,
+    ]);
+
+    expect(runner.requests[0]?.signal?.aborted).toBe(true);
+    expect(result).toMatchObject({
+      status: "cancelled",
+      metadata: {
+        cancelled: true,
+      },
+    });
+    expect(events).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: "lifecycle", status: "started" }),
+        expect.objectContaining({ type: "lifecycle", status: "cancelled" }),
+      ]),
+    );
+    expect(events).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: "error" }),
+      ]),
+    );
+  });
+
+  it("redacts sensitive configured command args", async () => {
+    const runner = new FakeRunner([success("Done.\n")]);
+    const adapter = new CodexAdapter({
+      runner,
+      defaultArgs: ["--token", "secret-token", "--api-key=secret-key"],
+    });
+    const handle = await adapter.run({
+      runId: "run-redact",
+      workstreamId: "workstream-1",
+      role: "build",
+      goal: "Do the task.",
+      workspacePath: "/tmp/workspace",
+    });
+
+    const events = await collect(handle.events);
+    const commandEvent = events.find((event) => event.type === "command");
+
+    expect(commandEvent).toMatchObject({
+      type: "command",
+      command:
+        'codex exec --sandbox workspace-write --token "[redacted]" "--api-key=[redacted]" "[redacted]"',
+    });
+    expect(commandEvent).not.toMatchObject({
+      command: expect.stringContaining("secret"),
+    });
+  });
+
+  it("captures text output and maps a non-zero exit to a failed result", async () => {
+    const runner = new FakeRunner([
+      {
+        exitCode: 2,
+        stdout: "partial text result\n",
+        stderr: "Codex failed\n",
+      },
+    ]);
+    const adapter = new CodexAdapter({ runner });
+    const handle = await adapter.run({
+      runId: "run-2",
+      workstreamId: "workstream-1",
+      role: "build",
+      goal: "Fail this run.",
+      workspacePath: "/tmp/workspace",
+    });
+
+    const [events, result] = await Promise.all([
+      collect(handle.events),
+      handle.result,
+    ]);
+
+    expect(result).toMatchObject({
+      status: "failed",
+      summary: "partial text result",
+      errorMessage: "Codex failed",
+      metadata: {
+        exitCode: 2,
+      },
+    });
+    expect(events).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "artifact",
+          artifactType: "log",
+          content: "partial text result\n",
+          metadata: { stream: "stdout", source: "final" },
+        }),
+        expect.objectContaining({
+          type: "artifact",
+          artifactType: "log",
+          content: "Codex failed\n",
+          metadata: { stream: "stderr", source: "final" },
+        }),
+        expect.objectContaining({
+          type: "error",
+          message: "Codex failed",
+          code: "CODEX_EXIT_2",
+        }),
+        expect.objectContaining({ type: "lifecycle", status: "failed" }),
+      ]),
+    );
+  });
+});

--- a/packages/codex-adapter/tsconfig.json
+++ b/packages/codex-adapter/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "declaration": true,
+    "emitDeclarationOnly": false,
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "dist",
+    "rootDir": "src",
+    "noEmit": false,
+    "types": ["node", "vitest/globals"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["dist", "test"]
+}


### PR DESCRIPTION
## Summary
- Adds the first-party `@mergepilot/codex-adapter` package for running OpenAI Codex CLI through the provider-neutral agent adapter contract.
- Implements CLI detection, bounded health checks, bounded task execution, cancellation mapping, prompt/argument redaction, waiting-for-input event normalization, and post-run diff artifact capture.
- Documents Codex adapter behavior and adds fake-runner tests for detection, health, success/failure/cancelled runs, redaction, buffer bounds, diff collection bounds, and session passthrough.

Closes #13

## Verification
- `npm run verify`
- `node -e "import('@mergepilot/codex-adapter').then(m => console.log(Object.keys(m).sort().join(',')))"`
- `git diff --check`
- `npm audit --omit=dev`
- Added-line static scan for hardcoded secrets and risky shell/eval patterns
- Independent review after fixes: pass/no blockers
