### PR TITLE
feat: add local orchestrator persistence

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -7,13 +7,17 @@
     "dev": "concurrently -k -n renderer,electron -c cyan,magenta \"npm run dev -w @mergepilot/web\" \"npm run dev:electron\"",
     "dev:electron": "npm run build:main && wait-on tcp:5173 && cross-env VITE_DEV_SERVER_URL=http://localhost:5173 electron .",
     "build": "npm run build:main",
-    "build:main": "tsc -p tsconfig.json",
-    "typecheck": "tsc -p tsconfig.json --noEmit"
+    "build:main": "npm run build -w @mergepilot/orchestrator && tsc -p tsconfig.json",
+    "typecheck": "npm run build -w @mergepilot/orchestrator && tsc -p tsconfig.json --noEmit",
+    "test": "vitest run"
   },
   "dependencies": {
+    "@mergepilot/orchestrator": "0.0.0",
     "@mergepilot/web": "0.0.0"
   },
   "devDependencies": {
-    "electron": "^35.2.1"
-  }
+    "electron": "^35.2.1",
+    "vitest": "^3.1.2"
+  },
+  "type": "module"
 }

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -1,7 +1,14 @@
 import { app, BrowserWindow, ipcMain } from "electron";
+import { createLocalOrchestrator } from "@mergepilot/orchestrator";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { registerOrchestratorIpcHandlers } from "./orchestrator-ipc.js";
 
 const rendererDevServerUrl = process.env.VITE_DEV_SERVER_URL;
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const orchestrator = createLocalOrchestrator({
+  dataDir: path.join(app.getPath("userData"), "orchestrator")
+});
 
 function getPreloadPath(): string {
   return path.join(__dirname, "../preload/preload.js");
@@ -43,10 +50,14 @@ function registerIpcHandlers(): void {
     electronVersion: process.versions.electron,
     platform: process.platform
   }));
+  registerOrchestratorIpcHandlers(ipcMain, orchestrator);
 }
 
 app.whenReady().then(async () => {
   registerIpcHandlers();
+  if (rendererDevServerUrl) {
+    await orchestrator.start();
+  }
   await createMainWindow();
 
   app.on("activate", async () => {
@@ -54,6 +65,10 @@ app.whenReady().then(async () => {
       await createMainWindow();
     }
   });
+});
+
+app.on("before-quit", () => {
+  void orchestrator.stop();
 });
 
 app.on("window-all-closed", () => {

--- a/apps/desktop/src/main/orchestrator-ipc.test.ts
+++ b/apps/desktop/src/main/orchestrator-ipc.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it, vi } from "vitest";
+import { registerOrchestratorIpcHandlers } from "./orchestrator-ipc.js";
+import { TestableOrchestratorIpc } from "./orchestrator-ipc.js";
+
+function createFakeIpc(): TestableOrchestratorIpc {
+  const handlers = new Map<string, (event: unknown, ...args: unknown[]) => unknown>();
+
+  return {
+    handle: vi.fn((channel: string, handler: (event: unknown, ...args: unknown[]) => unknown) => {
+      handlers.set(channel, handler);
+    }),
+    async invoke(channel: string, ...args: unknown[]) {
+      const handler = handlers.get(channel);
+      if (!handler) {
+        throw new Error(`Missing handler for ${channel}`);
+      }
+      return handler({}, ...args);
+    }
+  };
+}
+
+describe("orchestrator IPC handlers", () => {
+  it("registers lifecycle, workstream, and event handlers", async () => {
+    const ipc = createFakeIpc();
+    const orchestrator = {
+      start: vi.fn(async () => undefined),
+      stop: vi.fn(async () => undefined),
+      status: vi.fn(() => ({ state: "running", dataDir: "/tmp/data" })),
+      createWorkstream: vi.fn(() => ({ id: "ws-1", title: "IPC work", status: "active" })),
+      listWorkstreams: vi.fn(() => []),
+      getWorkstream: vi.fn(() => ({ id: "ws-1", title: "IPC work" })),
+      appendEvent: vi.fn(() => ({ id: "evt-1", workstreamId: "ws-1", sequence: 1 })),
+      listEvents: vi.fn(() => [])
+    };
+
+    registerOrchestratorIpcHandlers(ipc, orchestrator);
+
+    await expect(ipc.invoke("orchestrator:start")).resolves.toEqual({ state: "running", dataDir: "/tmp/data" });
+    await expect(
+      ipc.invoke("workstreams:create", { title: "IPC work", repositoryPath: "/tmp/repo" })
+    ).resolves.toMatchObject({ id: "ws-1" });
+    await ipc.invoke("events:append", {
+      workstreamId: "ws-1",
+      type: "ipc.event",
+      message: "IPC event",
+      payload: { ok: true }
+    });
+
+    expect(orchestrator.createWorkstream).toHaveBeenCalledWith({
+      title: "IPC work",
+      repositoryPath: "/tmp/repo"
+    });
+    expect(orchestrator.appendEvent).toHaveBeenCalledWith({
+      workstreamId: "ws-1",
+      type: "ipc.event",
+      message: "IPC event",
+      payload: { ok: true }
+    });
+  });
+
+  it("validates IPC input before calling services", async () => {
+    const ipc = createFakeIpc();
+    const orchestrator = {
+      start: vi.fn(),
+      stop: vi.fn(),
+      status: vi.fn(),
+      createWorkstream: vi.fn(),
+      listWorkstreams: vi.fn(),
+      getWorkstream: vi.fn(),
+      appendEvent: vi.fn(),
+      listEvents: vi.fn()
+    };
+
+    registerOrchestratorIpcHandlers(ipc, orchestrator);
+
+    await expect(ipc.invoke("workstreams:create", { title: "" })).rejects.toThrow(/title/i);
+    await expect(ipc.invoke("events:list", { workstreamId: "../bad" })).rejects.toThrow(/workstreamId/i);
+    expect(orchestrator.createWorkstream).not.toHaveBeenCalled();
+    expect(orchestrator.listEvents).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/main/orchestrator-ipc.ts
+++ b/apps/desktop/src/main/orchestrator-ipc.ts
@@ -1,0 +1,147 @@
+import type {
+  AppendWorkstreamEventInput,
+  CreateWorkstreamInput,
+  LocalOrchestratorService
+} from "@mergepilot/orchestrator";
+
+export interface OrchestratorIpc {
+  handle(channel: string, listener: (event: unknown, ...args: unknown[]) => unknown): void;
+}
+
+export interface TestableOrchestratorIpc extends OrchestratorIpc {
+  invoke(channel: string, ...args: unknown[]): Promise<unknown>;
+}
+
+export function registerOrchestratorIpcHandlers(
+  ipc: OrchestratorIpc,
+  orchestrator: Pick<
+    LocalOrchestratorService,
+    | "start"
+    | "stop"
+    | "status"
+    | "createWorkstream"
+    | "listWorkstreams"
+    | "getWorkstream"
+    | "appendEvent"
+    | "listEvents"
+  >
+): void {
+  ipc.handle("orchestrator:start", async () => {
+    await orchestrator.start();
+    return orchestrator.status();
+  });
+
+  ipc.handle("orchestrator:stop", async () => {
+    await orchestrator.stop();
+    return orchestrator.status();
+  });
+
+  ipc.handle("orchestrator:status", () => orchestrator.status());
+
+  ipc.handle("workstreams:create", (_event, rawInput) => {
+    return orchestrator.createWorkstream(parseCreateWorkstreamInput(rawInput));
+  });
+
+  ipc.handle("workstreams:list", () => orchestrator.listWorkstreams());
+
+  ipc.handle("workstreams:get", (_event, rawInput) => {
+    const id = parseIdInput(rawInput, "workstreamId");
+    return orchestrator.getWorkstream(id);
+  });
+
+  ipc.handle("events:append", (_event, rawInput) => {
+    return orchestrator.appendEvent(parseAppendEventInput(rawInput));
+  });
+
+  ipc.handle("events:list", (_event, rawInput) => {
+    const workstreamId = parseIdInput(rawInput, "workstreamId");
+    return orchestrator.listEvents(workstreamId);
+  });
+}
+
+function parseCreateWorkstreamInput(rawInput: unknown): CreateWorkstreamInput {
+  const input = requireRecord(rawInput);
+  const parsed: CreateWorkstreamInput = {
+    title: requireBoundedString(input.title, "title", 160)
+  };
+
+  if ("description" in input) {
+    parsed.description = optionalBoundedString(input.description, "description", 5000);
+  }
+  if ("repositoryPath" in input) {
+    parsed.repositoryPath = optionalBoundedString(input.repositoryPath, "repositoryPath", 2048);
+  }
+
+  return parsed;
+}
+
+function parseAppendEventInput(rawInput: unknown): AppendWorkstreamEventInput {
+  const input = requireRecord(rawInput);
+  const parsed: AppendWorkstreamEventInput = {
+    workstreamId: parseIdInput(input.workstreamId, "workstreamId"),
+    type: requireEventType(input.type),
+    message: requireBoundedString(input.message, "message", 2000)
+  };
+
+  if ("payload" in input) {
+    assertJsonCompatible(input.payload);
+    parsed.payload = input.payload;
+  }
+
+  return parsed;
+}
+
+function parseIdInput(rawInput: unknown, field: string): string {
+  const value = typeof rawInput === "object" && rawInput !== null && field in rawInput
+    ? (rawInput as Record<string, unknown>)[field]
+    : rawInput;
+  const id = requireBoundedString(value, field, 128);
+  if (!/^[A-Za-z0-9][A-Za-z0-9_-]{0,127}$/.test(id)) {
+    throw new Error(`${field} must be a valid local id.`);
+  }
+  return id;
+}
+
+function requireRecord(value: unknown): Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new Error("IPC input must be an object.");
+  }
+  return value as Record<string, unknown>;
+}
+
+function requireBoundedString(value: unknown, field: string, maxLength: number): string {
+  if (typeof value !== "string") {
+    throw new Error(`${field} must be a string.`);
+  }
+  const trimmed = value.trim();
+  if (!trimmed) {
+    throw new Error(`${field} is required.`);
+  }
+  if (trimmed.length > maxLength) {
+    throw new Error(`${field} must be ${maxLength} characters or fewer.`);
+  }
+  return trimmed;
+}
+
+function optionalBoundedString(value: unknown, field: string, maxLength: number): string | null {
+  if (value === undefined || value === null) {
+    return null;
+  }
+  return requireBoundedString(value, field, maxLength);
+}
+
+function requireEventType(value: unknown): string {
+  const type = requireBoundedString(value, "type", 128);
+  if (!/^[a-z][a-z0-9.:_-]{0,127}$/.test(type)) {
+    throw new Error("type must be a valid event type.");
+  }
+  return type;
+}
+
+function assertJsonCompatible(value: unknown): void {
+  try {
+    JSON.stringify(value);
+  } catch {
+    throw new Error("payload must be JSON serializable.");
+  }
+}

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -7,12 +7,65 @@ export interface MergePilotRuntimeInfo {
   platform: NodeJS.Platform;
 }
 
+export interface OrchestratorStatus {
+  state: "stopped" | "running";
+  dataDir: string;
+  databasePath: string;
+}
+
+export interface Workstream {
+  id: string;
+  title: string;
+  description: string | null;
+  repositoryPath: string | null;
+  status: "active" | "paused" | "completed" | "archived";
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CreateWorkstreamInput {
+  title: string;
+  description?: string | null;
+  repositoryPath?: string | null;
+}
+
+export interface WorkstreamEvent {
+  id: string;
+  workstreamId: string;
+  sequence: number;
+  type: string;
+  message: string;
+  payload: unknown | null;
+  createdAt: string;
+}
+
+export interface AppendWorkstreamEventInput {
+  workstreamId: string;
+  type: string;
+  message: string;
+  payload?: unknown;
+}
+
 export interface MergePilotDesktopApi {
   readonly appInfo: {
     readonly name: "MergePilot";
     readonly shell: "electron";
   };
   getRuntimeInfo(): Promise<MergePilotRuntimeInfo>;
+  orchestrator: {
+    start(): Promise<OrchestratorStatus>;
+    stop(): Promise<OrchestratorStatus>;
+    status(): Promise<OrchestratorStatus>;
+  };
+  workstreams: {
+    create(input: CreateWorkstreamInput): Promise<Workstream>;
+    list(): Promise<Workstream[]>;
+    get(id: string): Promise<Workstream | null>;
+  };
+  events: {
+    append(input: AppendWorkstreamEventInput): Promise<WorkstreamEvent>;
+    list(workstreamId: string): Promise<WorkstreamEvent[]>;
+  };
 }
 
 const desktopApi: MergePilotDesktopApi = {
@@ -20,7 +73,21 @@ const desktopApi: MergePilotDesktopApi = {
     name: "MergePilot",
     shell: "electron"
   },
-  getRuntimeInfo: () => ipcRenderer.invoke("app:get-runtime-info")
+  getRuntimeInfo: () => ipcRenderer.invoke("app:get-runtime-info"),
+  orchestrator: {
+    start: () => ipcRenderer.invoke("orchestrator:start"),
+    stop: () => ipcRenderer.invoke("orchestrator:stop"),
+    status: () => ipcRenderer.invoke("orchestrator:status")
+  },
+  workstreams: {
+    create: (input) => ipcRenderer.invoke("workstreams:create", input),
+    list: () => ipcRenderer.invoke("workstreams:list"),
+    get: (id) => ipcRenderer.invoke("workstreams:get", { workstreamId: id })
+  },
+  events: {
+    append: (input) => ipcRenderer.invoke("events:append", input),
+    list: (workstreamId) => ipcRenderer.invoke("events:list", { workstreamId })
+  }
 };
 
 contextBridge.exposeInMainWorld("mergePilot", desktopApi);

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -7,6 +7,11 @@ interface RuntimeInfo {
   platform: string;
 }
 
+interface TimelineState {
+  selectedWorkstreamId: string | null;
+  events: WorkstreamEvent[];
+}
+
 const shellSections = [
   {
     label: "Workstreams",
@@ -27,12 +32,91 @@ const shellSections = [
 
 export function App() {
   const [runtimeInfo, setRuntimeInfo] = useState<RuntimeInfo | null>(null);
+  const [orchestratorStatus, setOrchestratorStatus] = useState<OrchestratorStatus | null>(null);
+  const [workstreams, setWorkstreams] = useState<Workstream[]>([]);
+  const [timeline, setTimeline] = useState<TimelineState>({ selectedWorkstreamId: null, events: [] });
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     window.mergePilot.getRuntimeInfo().then(setRuntimeInfo).catch(() => {
       setRuntimeInfo(null);
     });
+    refreshOrchestrator().catch((caught: unknown) => {
+      setError(caught instanceof Error ? caught.message : "Unable to load orchestrator state.");
+    });
   }, []);
+
+  async function refreshOrchestrator() {
+    const status = await window.mergePilot.orchestrator.status();
+    setOrchestratorStatus(status);
+
+    if (status.state !== "running") {
+      setWorkstreams([]);
+      setTimeline({ selectedWorkstreamId: null, events: [] });
+      return;
+    }
+
+    const nextWorkstreams = await window.mergePilot.workstreams.list();
+    setWorkstreams(nextWorkstreams);
+    const selected = nextWorkstreams[0]?.id ?? null;
+    setTimeline({
+      selectedWorkstreamId: selected,
+      events: selected ? await window.mergePilot.events.list(selected) : []
+    });
+  }
+
+  async function startOrchestrator() {
+    setError(null);
+    await window.mergePilot.orchestrator.start();
+    await refreshOrchestrator();
+  }
+
+  async function stopOrchestrator() {
+    setError(null);
+    const status = await window.mergePilot.orchestrator.stop();
+    setOrchestratorStatus(status);
+    setWorkstreams([]);
+    setTimeline({ selectedWorkstreamId: null, events: [] });
+  }
+
+  async function createWorkstream() {
+    setError(null);
+    try {
+      if (orchestratorStatus?.state !== "running") {
+        await window.mergePilot.orchestrator.start();
+      }
+      const created = await window.mergePilot.workstreams.create({
+        title: `Workstream ${workstreams.length + 1}`,
+        description: "Created through the secure Electron bridge."
+      });
+      await window.mergePilot.events.append({
+        workstreamId: created.id,
+        type: "workstream.created",
+        message: "Workstream created from renderer"
+      });
+      await refreshOrchestrator();
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : "Unable to create workstream.");
+    }
+  }
+
+  async function appendTimelineEvent(workstreamId: string) {
+    setError(null);
+    try {
+      await window.mergePilot.events.append({
+        workstreamId,
+        type: "timeline.note",
+        message: "Timeline note appended from renderer",
+        payload: { surface: "web" }
+      });
+      setTimeline({
+        selectedWorkstreamId: workstreamId,
+        events: await window.mergePilot.events.list(workstreamId)
+      });
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : "Unable to append event.");
+    }
+  }
 
   return (
     <main className="app-shell">
@@ -61,6 +145,11 @@ export function App() {
           <strong>{runtimeInfo?.electronVersion ? `Electron ${runtimeInfo.electronVersion}` : "Electron"}</strong>
           <small>{runtimeInfo?.platform ?? "Loading runtime"}</small>
         </div>
+        <div className="runtime-panel">
+          <span>Orchestrator</span>
+          <strong>{orchestratorStatus?.state ?? "checking"}</strong>
+          <small>{orchestratorStatus?.dataDir ?? "Local data path pending"}</small>
+        </div>
       </aside>
 
       <section className="workspace" id="workstreams">
@@ -69,19 +158,44 @@ export function App() {
             <p className="eyebrow">Local-first workspace</p>
             <h2>MergePilot app shell</h2>
           </div>
-          <button type="button">New Workstream</button>
+          <div className="header-actions">
+            <button type="button" className="secondary-button" onClick={startOrchestrator}>
+              Start
+            </button>
+            <button type="button" className="secondary-button" onClick={stopOrchestrator}>
+              Stop
+            </button>
+            <button type="button" onClick={createWorkstream}>
+              New Workstream
+            </button>
+          </div>
         </header>
+
+        {error ? <p className="error-banner">{error}</p> : null}
 
         <section className="summary-band" aria-label="Current workstream summary">
           <div>
             <span className="status-dot" aria-hidden="true" />
-            <p>Ready for the first workstream</p>
+            <p>{workstreams.length > 0 ? `${workstreams.length} persisted workstream(s)` : "Ready for the first workstream"}</p>
           </div>
-          <strong>Coordinator, build agents, PR checks, and human decisions will land in this desktop surface.</strong>
+          <strong>
+            {timeline.selectedWorkstreamId
+              ? "Renderer calls are crossing the preload boundary into local persistence."
+              : "Coordinator, build agents, PR checks, and human decisions will land in this desktop surface."}
+          </strong>
         </section>
 
         <div className="section-grid">
-          {shellSections.map((section) => (
+          {workstreams.length > 0 ? workstreams.slice(0, 3).map((workstream) => (
+            <article className="section-card" key={workstream.id}>
+              <p className="eyebrow">{workstream.status}</p>
+              <h3>{workstream.title}</h3>
+              <p>{workstream.description ?? "No description"}</p>
+              <button type="button" className="inline-button" onClick={() => appendTimelineEvent(workstream.id)}>
+                Add event
+              </button>
+            </article>
+          )) : shellSections.map((section) => (
             <article className="section-card" key={section.label}>
               <p className="eyebrow">{section.label}</p>
               <h3>{section.title}</h3>
@@ -91,20 +205,23 @@ export function App() {
         </div>
 
         <section className="timeline" id="timeline" aria-label="Event timeline">
-          <div className="timeline-row">
-            <span>01</span>
-            <div>
-              <strong>Desktop shell booted</strong>
-              <p>Renderer is isolated from Node and talks through the typed preload API.</p>
+          {timeline.events.length > 0 ? timeline.events.map((event) => (
+            <div className="timeline-row" key={event.id}>
+              <span>{String(event.sequence).padStart(2, "0")}</span>
+              <div>
+                <strong>{event.type}</strong>
+                <p>{event.message}</p>
+              </div>
             </div>
-          </div>
-          <div className="timeline-row muted">
-            <span>02</span>
-            <div>
-              <strong>Orchestrator pending</strong>
-              <p>Local Node services, persistence, and agent adapters will be added behind this shell.</p>
+          )) : (
+            <div className="timeline-row muted">
+              <span>01</span>
+              <div>
+                <strong>Awaiting persisted events</strong>
+                <p>Create a workstream to append and read local timeline data.</p>
+              </div>
             </div>
-          </div>
+          )}
         </section>
       </section>
     </main>

--- a/apps/web/src/global.d.ts
+++ b/apps/web/src/global.d.ts
@@ -5,12 +5,65 @@ interface MergePilotRuntimeInfo {
   platform: string;
 }
 
+interface OrchestratorStatus {
+  state: "stopped" | "running";
+  dataDir: string;
+  databasePath: string;
+}
+
+interface Workstream {
+  id: string;
+  title: string;
+  description: string | null;
+  repositoryPath: string | null;
+  status: "active" | "paused" | "completed" | "archived";
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface CreateWorkstreamInput {
+  title: string;
+  description?: string | null;
+  repositoryPath?: string | null;
+}
+
+interface WorkstreamEvent {
+  id: string;
+  workstreamId: string;
+  sequence: number;
+  type: string;
+  message: string;
+  payload: unknown | null;
+  createdAt: string;
+}
+
+interface AppendWorkstreamEventInput {
+  workstreamId: string;
+  type: string;
+  message: string;
+  payload?: unknown;
+}
+
 interface MergePilotDesktopApi {
   readonly appInfo: {
     readonly name: "MergePilot";
     readonly shell: "electron";
   };
   getRuntimeInfo(): Promise<MergePilotRuntimeInfo>;
+  orchestrator: {
+    start(): Promise<OrchestratorStatus>;
+    stop(): Promise<OrchestratorStatus>;
+    status(): Promise<OrchestratorStatus>;
+  };
+  workstreams: {
+    create(input: CreateWorkstreamInput): Promise<Workstream>;
+    list(): Promise<Workstream[]>;
+    get(id: string): Promise<Workstream | null>;
+  };
+  events: {
+    append(input: AppendWorkstreamEventInput): Promise<WorkstreamEvent>;
+    list(workstreamId: string): Promise<WorkstreamEvent[]>;
+  };
 }
 
 interface Window {

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -141,7 +141,8 @@ h3 {
   margin-bottom: 28px;
 }
 
-.workspace-header button {
+.workspace-header button,
+.inline-button {
   min-width: 150px;
   padding: 11px 16px;
   border: 0;
@@ -150,6 +151,32 @@ h3 {
   background: #1f6feb;
   font-weight: 700;
   cursor: pointer;
+}
+
+.header-actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.workspace-header .secondary-button,
+.inline-button {
+  min-width: auto;
+  color: #1d2735;
+  background: #e8edf5;
+}
+
+.inline-button {
+  margin-top: 12px;
+}
+
+.error-banner {
+  padding: 12px 14px;
+  border: 1px solid #f2b8b5;
+  border-radius: 8px;
+  color: #8c1d18;
+  background: #fff4f2;
 }
 
 .summary-band {
@@ -260,7 +287,8 @@ h3 {
     display: grid;
   }
 
-  .workspace-header button {
+  .workspace-header button,
+  .header-actions {
     width: 100%;
   }
 }

--- a/docs/orchestrator.md
+++ b/docs/orchestrator.md
@@ -1,0 +1,58 @@
+# Local Orchestrator
+
+MergePilot now includes an in-process local orchestrator service used by the Electron main process in dev mode. It is structured as the foundation for a separate local process later: renderer code talks through preload IPC, main owns lifecycle, and persistence lives behind the `@mergepilot/orchestrator` package.
+
+## Persistence
+
+The orchestrator stores data in SQLite through `better-sqlite3`.
+
+- Package: `packages/orchestrator`
+- Default database file: `mergepilot.sqlite3`
+- Desktop location: `${app.getPath("userData")}/orchestrator/mergepilot.sqlite3`
+- Tests use temporary directories under the OS temp folder and never touch user data.
+
+Initial tables cover:
+
+- `workstreams`
+- `workstream_events`
+- `plans`
+- `agent_runs`
+
+SQLite foreign keys are enabled and timeline events use a per-workstream sequence number for stable ordering.
+
+## Desktop Lifecycle
+
+In dev mode, the Electron main process starts the local orchestrator after `app.whenReady()` and stops it during `before-quit`. The renderer also has explicit start/stop controls for exercising lifecycle through the preload boundary.
+
+Current lifecycle IPC:
+
+- `orchestrator:start`
+- `orchestrator:stop`
+- `orchestrator:status`
+
+This is currently an in-process service, not a spawned child process. The service boundary keeps startup, shutdown, status, and persistence ownership isolated so a separate process can replace the implementation without changing renderer calls.
+
+## Renderer IPC Surface
+
+The preload bridge exposes `window.mergePilot` with context isolation, disabled Node integration, and sandboxed renderer settings preserved.
+
+Available renderer calls:
+
+- `window.mergePilot.orchestrator.start()`
+- `window.mergePilot.orchestrator.stop()`
+- `window.mergePilot.orchestrator.status()`
+- `window.mergePilot.workstreams.create(input)`
+- `window.mergePilot.workstreams.list()`
+- `window.mergePilot.workstreams.get(id)`
+- `window.mergePilot.events.append(input)`
+- `window.mergePilot.events.list(workstreamId)`
+
+The renderer UI includes a small proof path: start/stop the orchestrator, create persisted workstreams, append timeline events, and read them back.
+
+## Safeguards
+
+- Renderer code cannot access Node APIs directly.
+- IPC handlers validate object shapes, bounded strings, local IDs, event type format, and JSON-serializable payloads before calling services.
+- No shell execution is used by the orchestrator or IPC layer.
+- Service methods reject data operations while stopped.
+- Tests cover persistence across store instances, service lifecycle behavior, timeline append/read ordering, plan/run persistence, and IPC validation.

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,10 +28,12 @@
       "name": "@mergepilot/desktop",
       "version": "0.0.0",
       "dependencies": {
+        "@mergepilot/orchestrator": "0.0.0",
         "@mergepilot/web": "0.0.0"
       },
       "devDependencies": {
-        "electron": "^35.2.1"
+        "electron": "^35.2.1",
+        "vitest": "^3.1.2"
       }
     },
     "apps/web": {
@@ -862,6 +864,10 @@
       "resolved": "apps/desktop",
       "link": true
     },
+    "node_modules/@mergepilot/orchestrator": {
+      "resolved": "packages/orchestrator",
+      "link": true
+    },
     "node_modules/@mergepilot/web": {
       "resolved": "apps/web",
       "link": true
@@ -1271,6 +1277,16 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/better-sqlite3": {
+      "version": "7.6.13",
+      "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz",
+      "integrity": "sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/cacheable-request": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.3.tgz",
@@ -1566,6 +1582,26 @@
         "proxy-from-env": "^2.1.0"
       }
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.25",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.25.tgz",
@@ -1576,6 +1612,37 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/better-sqlite3": {
+      "version": "11.10.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-11.10.0.tgz",
+      "integrity": "sha512-EwhOpyXiOEL/lKzHz9AW1msWFNzGc/z+LzeB3/jnFJpxu+th2yqvzsSWas1v9jgs9+xiXJcD5A8CJxAG2TaghQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
       }
     },
     "node_modules/boolean": {
@@ -1618,6 +1685,30 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
       }
     },
     "node_modules/buffer-crc32": {
@@ -1759,6 +1850,12 @@
       "engines": {
         "node": ">= 16"
       }
+    },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC"
     },
     "node_modules/cliui": {
       "version": "8.0.1",
@@ -1914,7 +2011,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
       "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mimic-response": "^3.1.0"
@@ -1930,7 +2026,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
       "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -1947,6 +2042,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
     "node_modules/defer-to-connect": {
@@ -2005,6 +2109,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/detect-node": {
@@ -2066,7 +2179,6 @@
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
       "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "once": "^1.4.0"
@@ -2220,6 +2332,15 @@
         "@types/estree": "^1.0.0"
       }
     },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -2278,6 +2399,12 @@
         }
       }
     },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT"
+    },
     "node_modules/follow-redirects": {
       "version": "1.16.0",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
@@ -2315,6 +2442,12 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT"
     },
     "node_modules/fs-extra": {
       "version": "8.1.0",
@@ -2428,6 +2561,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT"
     },
     "node_modules/global-agent": {
       "version": "3.0.0",
@@ -2612,6 +2751,38 @@
       "engines": {
         "node": ">=10.19.0"
       }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "license": "ISC"
     },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
@@ -2818,11 +2989,16 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -2846,6 +3022,36 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "license": "MIT"
+    },
+    "node_modules/node-abi": {
+      "version": "3.90.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.90.0.tgz",
+      "integrity": "sha512-pZNQT7UnYlMwMBy5N1lV5X/YLTbZM5ncytN3xL7CHEzhDN8uVe0u55yaPUJICIJjaCW8NrM5BFdqr7HLweStNA==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/node-abi/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/node-releases": {
@@ -2882,7 +3088,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -2978,6 +3183,33 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/progress": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
@@ -3002,7 +3234,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
       "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "end-of-stream": "^1.1.0",
@@ -3020,6 +3251,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
       }
     },
     "node_modules/react": {
@@ -3050,6 +3296,20 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/require-directory": {
@@ -3155,6 +3415,26 @@
         "tslib": "^2.1.0"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/scheduler": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
@@ -3238,6 +3518,51 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -3269,6 +3594,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
     "node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
@@ -3295,6 +3629,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/strip-literal": {
@@ -3344,6 +3687,34 @@
       },
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/tinybench": {
@@ -3423,6 +3794,18 @@
       "dev": true,
       "license": "0BSD"
     },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/type-fest": {
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
@@ -3496,6 +3879,12 @@
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
     },
     "node_modules/vite": {
       "version": "6.4.2",
@@ -3742,7 +4131,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/y18n": {
@@ -3825,6 +4213,17 @@
         "@mergepilot/agents": "0.0.0"
       },
       "devDependencies": {
+        "vitest": "^3.1.2"
+      }
+    },
+    "packages/orchestrator": {
+      "name": "@mergepilot/orchestrator",
+      "version": "0.0.0",
+      "dependencies": {
+        "better-sqlite3": "^11.9.1"
+      },
+      "devDependencies": {
+        "@types/better-sqlite3": "^7.6.13",
         "vitest": "^3.1.2"
       }
     }

--- a/packages/orchestrator/package.json
+++ b/packages/orchestrator/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@mergepilot/orchestrator",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "vitest run"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "dependencies": {
+    "better-sqlite3": "^11.9.1"
+  },
+  "devDependencies": {
+    "@types/better-sqlite3": "^7.6.13",
+    "vitest": "^3.1.2"
+  }
+}

--- a/packages/orchestrator/src/index.ts
+++ b/packages/orchestrator/src/index.ts
@@ -1,0 +1,25 @@
+export {
+  createSqliteOrchestratorStore,
+  SqliteOrchestratorStore
+} from "./sqlite-store.js";
+export {
+  createLocalOrchestrator,
+  InProcessLocalOrchestrator
+} from "./service.js";
+export type {
+  AgentRun,
+  AgentRunStatus,
+  AppendWorkstreamEventInput,
+  CreateAgentRunInput,
+  CreatePlanInput,
+  CreateWorkstreamInput,
+  LocalOrchestratorService,
+  OrchestratorState,
+  OrchestratorStatus,
+  OrchestratorStore,
+  Plan,
+  PlanStatus,
+  Workstream,
+  WorkstreamEvent,
+  WorkstreamStatus
+} from "./types.js";

--- a/packages/orchestrator/src/service.ts
+++ b/packages/orchestrator/src/service.ts
@@ -1,0 +1,92 @@
+import path from "node:path";
+import {
+  AppendWorkstreamEventInput,
+  CreateAgentRunInput,
+  CreatePlanInput,
+  CreateWorkstreamInput,
+  LocalOrchestratorService,
+  OrchestratorStatus,
+  OrchestratorStore
+} from "./types.js";
+import { createSqliteOrchestratorStore } from "./sqlite-store.js";
+
+export interface LocalOrchestratorOptions {
+  dataDir: string;
+}
+
+export class InProcessLocalOrchestrator implements LocalOrchestratorService {
+  private store: OrchestratorStore | null = null;
+  private readonly databasePath: string;
+
+  constructor(private readonly options: LocalOrchestratorOptions) {
+    this.databasePath = path.join(options.dataDir, "mergepilot.sqlite3");
+  }
+
+  async start(): Promise<void> {
+    if (this.store) {
+      return;
+    }
+
+    this.store = createSqliteOrchestratorStore({ dataDir: this.options.dataDir });
+  }
+
+  async stop(): Promise<void> {
+    this.store?.close();
+    this.store = null;
+  }
+
+  status(): OrchestratorStatus {
+    return {
+      state: this.store ? "running" : "stopped",
+      dataDir: this.options.dataDir,
+      databasePath: this.databasePath
+    };
+  }
+
+  createWorkstream(input: CreateWorkstreamInput) {
+    return this.requireStore().createWorkstream(input);
+  }
+
+  listWorkstreams() {
+    return this.requireStore().listWorkstreams();
+  }
+
+  getWorkstream(id: string) {
+    return this.requireStore().getWorkstream(id);
+  }
+
+  appendEvent(input: AppendWorkstreamEventInput) {
+    return this.requireStore().appendEvent(input);
+  }
+
+  listEvents(workstreamId: string) {
+    return this.requireStore().listEvents(workstreamId);
+  }
+
+  createPlan(input: CreatePlanInput) {
+    return this.requireStore().createPlan(input);
+  }
+
+  listPlans(workstreamId: string) {
+    return this.requireStore().listPlans(workstreamId);
+  }
+
+  createAgentRun(input: CreateAgentRunInput) {
+    return this.requireStore().createAgentRun(input);
+  }
+
+  listAgentRuns(workstreamId: string) {
+    return this.requireStore().listAgentRuns(workstreamId);
+  }
+
+  private requireStore(): OrchestratorStore {
+    if (!this.store) {
+      throw new Error("Local orchestrator is not running.");
+    }
+    return this.store;
+  }
+}
+
+export function createLocalOrchestrator(options: LocalOrchestratorOptions): LocalOrchestratorService {
+  return new InProcessLocalOrchestrator(options);
+}

--- a/packages/orchestrator/src/sqlite-store.ts
+++ b/packages/orchestrator/src/sqlite-store.ts
@@ -1,0 +1,360 @@
+import Database from "better-sqlite3";
+import { mkdirSync } from "node:fs";
+import path from "node:path";
+import { randomUUID } from "node:crypto";
+import {
+  AgentRun,
+  AppendWorkstreamEventInput,
+  CreateAgentRunInput,
+  CreatePlanInput,
+  CreateWorkstreamInput,
+  OrchestratorStore,
+  Plan,
+  Workstream,
+  WorkstreamEvent
+} from "./types.js";
+import {
+  assertJsonCompatible,
+  normalizeOptionalString,
+  requireAgentRunStatus,
+  requireEventType,
+  requireId,
+  requirePlanStatus,
+  requireString
+} from "./validation.js";
+
+export interface SqliteStoreOptions {
+  dataDir: string;
+  databaseFileName?: string;
+}
+
+type WorkstreamRow = Omit<Workstream, "repositoryPath" | "createdAt" | "updatedAt"> & {
+  repository_path: string | null;
+  created_at: string;
+  updated_at: string;
+};
+
+type EventRow = Omit<WorkstreamEvent, "workstreamId" | "createdAt" | "payload"> & {
+  workstream_id: string;
+  created_at: string;
+  payload_json: string | null;
+};
+
+type PlanRow = Omit<Plan, "workstreamId" | "createdAt" | "updatedAt"> & {
+  workstream_id: string;
+  created_at: string;
+  updated_at: string;
+};
+
+type AgentRunRow = Omit<
+  AgentRun,
+  "workstreamId" | "providerId" | "adapterId" | "startedAt" | "completedAt" | "createdAt" | "updatedAt"
+> & {
+  workstream_id: string;
+  provider_id: string;
+  adapter_id: string | null;
+  started_at: string | null;
+  completed_at: string | null;
+  created_at: string;
+  updated_at: string;
+};
+
+export class SqliteOrchestratorStore implements OrchestratorStore {
+  readonly databasePath: string;
+  private readonly db: Database.Database;
+
+  constructor(options: SqliteStoreOptions) {
+    const databaseFileName = options.databaseFileName ?? "mergepilot.sqlite3";
+    mkdirSync(options.dataDir, { recursive: true });
+    this.databasePath = path.join(options.dataDir, databaseFileName);
+    this.db = new Database(this.databasePath);
+    this.db.pragma("foreign_keys = ON");
+    this.db.pragma("journal_mode = WAL");
+    this.migrate();
+  }
+
+  createWorkstream(input: CreateWorkstreamInput): Workstream {
+    const now = new Date().toISOString();
+    const workstream: Workstream = {
+      id: randomUUID(),
+      title: requireString(input.title, "title", 160),
+      description: normalizeOptionalString(input.description, 5000),
+      repositoryPath: normalizeOptionalString(input.repositoryPath, 2048),
+      status: "active",
+      createdAt: now,
+      updatedAt: now
+    };
+
+    this.db
+      .prepare(
+        `INSERT INTO workstreams (id, title, description, repository_path, status, created_at, updated_at)
+         VALUES (@id, @title, @description, @repositoryPath, @status, @createdAt, @updatedAt)`
+      )
+      .run(workstream);
+
+    return workstream;
+  }
+
+  listWorkstreams(): Workstream[] {
+    const rows = this.db
+      .prepare("SELECT * FROM workstreams ORDER BY updated_at DESC, created_at DESC")
+      .all() as WorkstreamRow[];
+    return rows.map(mapWorkstreamRow);
+  }
+
+  getWorkstream(id: string): Workstream | null {
+    const row = this.db.prepare("SELECT * FROM workstreams WHERE id = ?").get(requireId(id)) as
+      | WorkstreamRow
+      | undefined;
+    return row ? mapWorkstreamRow(row) : null;
+  }
+
+  appendEvent(input: AppendWorkstreamEventInput): WorkstreamEvent {
+    const workstreamId = requireId(input.workstreamId, "workstreamId");
+    this.requireWorkstream(workstreamId);
+    const type = requireEventType(input.type);
+    const message = requireString(input.message, "message", 2000);
+    assertJsonCompatible(input.payload);
+
+    const event = this.db.transaction(() => {
+      const nextSequence =
+        ((this.db
+          .prepare("SELECT COALESCE(MAX(sequence), 0) + 1 AS sequence FROM workstream_events WHERE workstream_id = ?")
+          .get(workstreamId) as { sequence: number }).sequence ?? 1);
+      const createdAt = new Date().toISOString();
+      const record = {
+        id: randomUUID(),
+        workstreamId,
+        sequence: nextSequence,
+        type,
+        message,
+        payloadJson: input.payload === undefined ? null : JSON.stringify(input.payload),
+        createdAt
+      };
+
+      this.db
+        .prepare(
+          `INSERT INTO workstream_events (id, workstream_id, sequence, type, message, payload_json, created_at)
+           VALUES (@id, @workstreamId, @sequence, @type, @message, @payloadJson, @createdAt)`
+        )
+        .run(record);
+      this.db.prepare("UPDATE workstreams SET updated_at = ? WHERE id = ?").run(createdAt, workstreamId);
+
+      return {
+        id: record.id,
+        workstreamId,
+        sequence: nextSequence,
+        type,
+        message,
+        payload: input.payload === undefined ? null : input.payload,
+        createdAt
+      };
+    })();
+
+    return event;
+  }
+
+  listEvents(workstreamId: string): WorkstreamEvent[] {
+    const id = requireId(workstreamId, "workstreamId");
+    this.requireWorkstream(id);
+    const rows = this.db
+      .prepare("SELECT * FROM workstream_events WHERE workstream_id = ? ORDER BY sequence ASC")
+      .all(id) as EventRow[];
+    return rows.map(mapEventRow);
+  }
+
+  createPlan(input: CreatePlanInput): Plan {
+    const workstreamId = requireId(input.workstreamId, "workstreamId");
+    this.requireWorkstream(workstreamId);
+    const now = new Date().toISOString();
+    const plan: Plan = {
+      id: randomUUID(),
+      workstreamId,
+      title: requireString(input.title, "title", 160),
+      body: requireString(input.body, "body", 100000),
+      status: input.status ? requirePlanStatus(input.status) : "draft",
+      createdAt: now,
+      updatedAt: now
+    };
+
+    this.db
+      .prepare(
+        `INSERT INTO plans (id, workstream_id, title, body, status, created_at, updated_at)
+         VALUES (@id, @workstreamId, @title, @body, @status, @createdAt, @updatedAt)`
+      )
+      .run(plan);
+    return plan;
+  }
+
+  listPlans(workstreamId: string): Plan[] {
+    const id = requireId(workstreamId, "workstreamId");
+    this.requireWorkstream(id);
+    const rows = this.db.prepare("SELECT * FROM plans WHERE workstream_id = ? ORDER BY created_at ASC").all(id) as PlanRow[];
+    return rows.map(mapPlanRow);
+  }
+
+  createAgentRun(input: CreateAgentRunInput): AgentRun {
+    const workstreamId = requireId(input.workstreamId, "workstreamId");
+    this.requireWorkstream(workstreamId);
+    const now = new Date().toISOString();
+    const run: AgentRun = {
+      id: randomUUID(),
+      workstreamId,
+      providerId: requireString(input.providerId, "providerId", 80),
+      adapterId: normalizeOptionalString(input.adapterId, 120),
+      role: requireString(input.role, "role", 80),
+      status: input.status ? requireAgentRunStatus(input.status) : "queued",
+      goal: requireString(input.goal, "goal", 5000),
+      startedAt: null,
+      completedAt: null,
+      createdAt: now,
+      updatedAt: now
+    };
+
+    this.db
+      .prepare(
+        `INSERT INTO agent_runs (
+           id, workstream_id, provider_id, adapter_id, role, status, goal,
+           started_at, completed_at, created_at, updated_at
+         )
+         VALUES (
+           @id, @workstreamId, @providerId, @adapterId, @role, @status, @goal,
+           @startedAt, @completedAt, @createdAt, @updatedAt
+         )`
+      )
+      .run(run);
+    return run;
+  }
+
+  listAgentRuns(workstreamId: string): AgentRun[] {
+    const id = requireId(workstreamId, "workstreamId");
+    this.requireWorkstream(id);
+    const rows = this.db
+      .prepare("SELECT * FROM agent_runs WHERE workstream_id = ? ORDER BY created_at ASC")
+      .all(id) as AgentRunRow[];
+    return rows.map(mapAgentRunRow);
+  }
+
+  close(): void {
+    this.db.close();
+  }
+
+  private requireWorkstream(workstreamId: string): void {
+    const row = this.db.prepare("SELECT id FROM workstreams WHERE id = ?").get(workstreamId);
+    if (!row) {
+      throw new Error(`Workstream ${workstreamId} was not found.`);
+    }
+  }
+
+  private migrate(): void {
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS workstreams (
+        id TEXT PRIMARY KEY,
+        title TEXT NOT NULL,
+        description TEXT,
+        repository_path TEXT,
+        status TEXT NOT NULL CHECK (status IN ('active', 'paused', 'completed', 'archived')),
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+      );
+
+      CREATE TABLE IF NOT EXISTS workstream_events (
+        id TEXT PRIMARY KEY,
+        workstream_id TEXT NOT NULL REFERENCES workstreams(id) ON DELETE CASCADE,
+        sequence INTEGER NOT NULL,
+        type TEXT NOT NULL,
+        message TEXT NOT NULL,
+        payload_json TEXT,
+        created_at TEXT NOT NULL,
+        UNIQUE(workstream_id, sequence)
+      );
+
+      CREATE TABLE IF NOT EXISTS plans (
+        id TEXT PRIMARY KEY,
+        workstream_id TEXT NOT NULL REFERENCES workstreams(id) ON DELETE CASCADE,
+        title TEXT NOT NULL,
+        body TEXT NOT NULL,
+        status TEXT NOT NULL CHECK (status IN ('draft', 'approved', 'rejected', 'superseded')),
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+      );
+
+      CREATE TABLE IF NOT EXISTS agent_runs (
+        id TEXT PRIMARY KEY,
+        workstream_id TEXT NOT NULL REFERENCES workstreams(id) ON DELETE CASCADE,
+        provider_id TEXT NOT NULL,
+        adapter_id TEXT,
+        role TEXT NOT NULL,
+        status TEXT NOT NULL CHECK (status IN ('queued', 'running', 'completed', 'failed', 'cancelled')),
+        goal TEXT NOT NULL,
+        started_at TEXT,
+        completed_at TEXT,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_workstream_events_workstream_sequence
+        ON workstream_events(workstream_id, sequence);
+      CREATE INDEX IF NOT EXISTS idx_plans_workstream
+        ON plans(workstream_id);
+      CREATE INDEX IF NOT EXISTS idx_agent_runs_workstream
+        ON agent_runs(workstream_id);
+    `);
+  }
+}
+
+export function createSqliteOrchestratorStore(options: SqliteStoreOptions): SqliteOrchestratorStore {
+  return new SqliteOrchestratorStore(options);
+}
+
+function mapWorkstreamRow(row: WorkstreamRow): Workstream {
+  return {
+    id: row.id,
+    title: row.title,
+    description: row.description,
+    repositoryPath: row.repository_path,
+    status: row.status,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at
+  };
+}
+
+function mapEventRow(row: EventRow): WorkstreamEvent {
+  return {
+    id: row.id,
+    workstreamId: row.workstream_id,
+    sequence: row.sequence,
+    type: row.type,
+    message: row.message,
+    payload: row.payload_json === null ? null : JSON.parse(row.payload_json),
+    createdAt: row.created_at
+  };
+}
+
+function mapPlanRow(row: PlanRow): Plan {
+  return {
+    id: row.id,
+    workstreamId: row.workstream_id,
+    title: row.title,
+    body: row.body,
+    status: row.status,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at
+  };
+}
+
+function mapAgentRunRow(row: AgentRunRow): AgentRun {
+  return {
+    id: row.id,
+    workstreamId: row.workstream_id,
+    providerId: row.provider_id,
+    adapterId: row.adapter_id,
+    role: row.role,
+    status: row.status,
+    goal: row.goal,
+    startedAt: row.started_at,
+    completedAt: row.completed_at,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at
+  };
+}

--- a/packages/orchestrator/src/types.ts
+++ b/packages/orchestrator/src/types.ts
@@ -1,0 +1,102 @@
+export type WorkstreamStatus = "active" | "paused" | "completed" | "archived";
+export type PlanStatus = "draft" | "approved" | "rejected" | "superseded";
+export type AgentRunStatus = "queued" | "running" | "completed" | "failed" | "cancelled";
+export type OrchestratorState = "stopped" | "running";
+
+export interface Workstream {
+  id: string;
+  title: string;
+  description: string | null;
+  repositoryPath: string | null;
+  status: WorkstreamStatus;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CreateWorkstreamInput {
+  title: string;
+  description?: string | null;
+  repositoryPath?: string | null;
+}
+
+export interface WorkstreamEvent {
+  id: string;
+  workstreamId: string;
+  sequence: number;
+  type: string;
+  message: string;
+  payload: unknown | null;
+  createdAt: string;
+}
+
+export interface AppendWorkstreamEventInput {
+  workstreamId: string;
+  type: string;
+  message: string;
+  payload?: unknown;
+}
+
+export interface Plan {
+  id: string;
+  workstreamId: string;
+  title: string;
+  body: string;
+  status: PlanStatus;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CreatePlanInput {
+  workstreamId: string;
+  title: string;
+  body: string;
+  status?: PlanStatus;
+}
+
+export interface AgentRun {
+  id: string;
+  workstreamId: string;
+  providerId: string;
+  adapterId: string | null;
+  role: string;
+  status: AgentRunStatus;
+  goal: string;
+  startedAt: string | null;
+  completedAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CreateAgentRunInput {
+  workstreamId: string;
+  providerId: string;
+  adapterId?: string | null;
+  role: string;
+  status?: AgentRunStatus;
+  goal: string;
+}
+
+export interface OrchestratorStore {
+  createWorkstream(input: CreateWorkstreamInput): Workstream;
+  listWorkstreams(): Workstream[];
+  getWorkstream(id: string): Workstream | null;
+  appendEvent(input: AppendWorkstreamEventInput): WorkstreamEvent;
+  listEvents(workstreamId: string): WorkstreamEvent[];
+  createPlan(input: CreatePlanInput): Plan;
+  listPlans(workstreamId: string): Plan[];
+  createAgentRun(input: CreateAgentRunInput): AgentRun;
+  listAgentRuns(workstreamId: string): AgentRun[];
+  close(): void;
+}
+
+export interface OrchestratorStatus {
+  state: OrchestratorState;
+  dataDir: string;
+  databasePath: string;
+}
+
+export interface LocalOrchestratorService extends Omit<OrchestratorStore, "close"> {
+  start(): Promise<void>;
+  stop(): Promise<void>;
+  status(): OrchestratorStatus;
+}

--- a/packages/orchestrator/src/validation.ts
+++ b/packages/orchestrator/src/validation.ts
@@ -1,0 +1,82 @@
+const idPattern = /^[A-Za-z0-9][A-Za-z0-9_-]{0,127}$/;
+const eventTypePattern = /^[a-z][a-z0-9.:_-]{0,127}$/;
+const planStatuses = new Set(["draft", "approved", "rejected", "superseded"]);
+const agentRunStatuses = new Set(["queued", "running", "completed", "failed", "cancelled"]);
+
+export function normalizeOptionalString(value: string | null | undefined, maxLength: number): string | null {
+  if (value === undefined || value === null) {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  if (trimmed.length > maxLength) {
+    throw new Error(`Value must be ${maxLength} characters or fewer.`);
+  }
+
+  return trimmed;
+}
+
+export function requireString(value: string, field: string, maxLength: number): string {
+  if (typeof value !== "string") {
+    throw new Error(`${field} must be a string.`);
+  }
+
+  const trimmed = value.trim();
+  if (!trimmed) {
+    throw new Error(`${field} is required.`);
+  }
+
+  if (trimmed.length > maxLength) {
+    throw new Error(`${field} must be ${maxLength} characters or fewer.`);
+  }
+
+  return trimmed;
+}
+
+export function requireId(value: string, field = "id"): string {
+  const trimmed = requireString(value, field, 128);
+  if (!idPattern.test(trimmed)) {
+    throw new Error(`${field} must be a valid local id.`);
+  }
+  return trimmed;
+}
+
+export function requireEventType(value: string): string {
+  const trimmed = requireString(value, "type", 128);
+  if (!eventTypePattern.test(trimmed)) {
+    throw new Error("type must be a valid event type.");
+  }
+  return trimmed;
+}
+
+export function requirePlanStatus(value: unknown): "draft" | "approved" | "rejected" | "superseded" {
+  const status = requireString(value as string, "status", 40);
+  if (!planStatuses.has(status)) {
+    throw new Error("status must be a valid plan status.");
+  }
+  return status as "draft" | "approved" | "rejected" | "superseded";
+}
+
+export function requireAgentRunStatus(value: unknown): "queued" | "running" | "completed" | "failed" | "cancelled" {
+  const status = requireString(value as string, "status", 40);
+  if (!agentRunStatuses.has(status)) {
+    throw new Error("status must be a valid agent run status.");
+  }
+  return status as "queued" | "running" | "completed" | "failed" | "cancelled";
+}
+
+export function assertJsonCompatible(value: unknown): void {
+  if (value === undefined) {
+    return;
+  }
+
+  try {
+    JSON.stringify(value);
+  } catch {
+    throw new Error("payload must be JSON serializable.");
+  }
+}

--- a/packages/orchestrator/test/persistence.test.ts
+++ b/packages/orchestrator/test/persistence.test.ts
@@ -1,0 +1,121 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { createSqliteOrchestratorStore } from "../src/index.js";
+
+const tempDirs: string[] = [];
+
+async function createTempDir(): Promise<string> {
+  const dir = await mkdtemp(path.join(tmpdir(), "mergepilot-orchestrator-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+describe("SqliteOrchestratorStore", () => {
+  it("persists workstreams across store instances", async () => {
+    const dataDir = await createTempDir();
+    const first = createSqliteOrchestratorStore({ dataDir });
+
+    const created = first.createWorkstream({
+      title: "Add orchestrator foundation",
+      repositoryPath: "/tmp/mergepilot",
+      description: "Track local work and event history."
+    });
+    first.close();
+
+    const second = createSqliteOrchestratorStore({ dataDir });
+
+    expect(second.listWorkstreams()).toEqual([
+      expect.objectContaining({
+        id: created.id,
+        title: "Add orchestrator foundation",
+        repositoryPath: "/tmp/mergepilot",
+        status: "active"
+      })
+    ]);
+    expect(second.getWorkstream(created.id)).toMatchObject({ id: created.id });
+    second.close();
+  });
+
+  it("appends and reads ordered timeline events with structured payloads", async () => {
+    const dataDir = await createTempDir();
+    const store = createSqliteOrchestratorStore({ dataDir });
+    const workstream = store.createWorkstream({ title: "Timeline coverage" });
+
+    const first = store.appendEvent({
+      workstreamId: workstream.id,
+      type: "workstream.created",
+      message: "Workstream created",
+      payload: { source: "test" }
+    });
+    const second = store.appendEvent({
+      workstreamId: workstream.id,
+      type: "agent.run.started",
+      message: "Agent run started"
+    });
+
+    expect(store.listEvents(workstream.id)).toEqual([
+      expect.objectContaining({
+        id: first.id,
+        sequence: 1,
+        payload: { source: "test" }
+      }),
+      expect.objectContaining({
+        id: second.id,
+        sequence: 2,
+        payload: null
+      })
+    ]);
+    store.close();
+  });
+
+  it("creates plans and agent runs linked to a workstream", async () => {
+    const dataDir = await createTempDir();
+    const store = createSqliteOrchestratorStore({ dataDir });
+    const workstream = store.createWorkstream({ title: "Agent run coverage" });
+
+    const plan = store.createPlan({
+      workstreamId: workstream.id,
+      title: "Implementation plan",
+      body: "Add persistence, services, and IPC.",
+      status: "draft"
+    });
+    const run = store.createAgentRun({
+      workstreamId: workstream.id,
+      providerId: "codex",
+      role: "build",
+      status: "queued",
+      goal: "Implement the orchestrator foundation."
+    });
+
+    expect(store.listPlans(workstream.id)).toEqual([expect.objectContaining({ id: plan.id })]);
+    expect(store.listAgentRuns(workstream.id)).toEqual([expect.objectContaining({ id: run.id })]);
+    store.close();
+  });
+
+  it("rejects invalid plan and agent run statuses at runtime", async () => {
+    const dataDir = await createTempDir();
+    const store = createSqliteOrchestratorStore({ dataDir });
+    const workstream = store.createWorkstream({ title: "Runtime validation" });
+
+    expect(() => store.createPlan({
+      workstreamId: workstream.id,
+      title: "Bad plan",
+      body: "Invalid status",
+      status: "done" as never
+    })).toThrow(/plan status/i);
+    expect(() => store.createAgentRun({
+      workstreamId: workstream.id,
+      providerId: "codex",
+      role: "build",
+      goal: "Invalid status",
+      status: "waiting" as never
+    })).toThrow(/agent run status/i);
+    store.close();
+  });
+});

--- a/packages/orchestrator/test/service.test.ts
+++ b/packages/orchestrator/test/service.test.ts
@@ -1,0 +1,50 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { createLocalOrchestrator } from "../src/index.js";
+
+const tempDirs: string[] = [];
+
+async function createTempDir(): Promise<string> {
+  const dir = await mkdtemp(path.join(tmpdir(), "mergepilot-service-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+describe("LocalOrchestratorService", () => {
+  it("starts, reports status, serves workstreams and stops", async () => {
+    const dataDir = await createTempDir();
+    const orchestrator = createLocalOrchestrator({ dataDir });
+
+    expect(orchestrator.status()).toMatchObject({ state: "stopped" });
+
+    await orchestrator.start();
+    expect(orchestrator.status()).toMatchObject({ state: "running", dataDir });
+
+    const workstream = orchestrator.createWorkstream({ title: "Service workstream" });
+    orchestrator.appendEvent({
+      workstreamId: workstream.id,
+      type: "service.ready",
+      message: "Service ready"
+    });
+
+    expect(orchestrator.listWorkstreams()).toEqual([expect.objectContaining({ id: workstream.id })]);
+    expect(orchestrator.listEvents(workstream.id)).toEqual([
+      expect.objectContaining({ type: "service.ready" })
+    ]);
+
+    await orchestrator.stop();
+    expect(orchestrator.status()).toMatchObject({ state: "stopped" });
+  });
+
+  it("rejects data operations while stopped", async () => {
+    const orchestrator = createLocalOrchestrator({ dataDir: await createTempDir() });
+
+    expect(() => orchestrator.listWorkstreams()).toThrow(/not running/i);
+  });
+});

--- a/packages/orchestrator/tsconfig.json
+++ b/packages/orchestrator/tsconfig.json
@@ -2,14 +2,15 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "composite": true,
+    "declaration": true,
+    "emitDeclarationOnly": false,
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "outDir": "dist",
     "rootDir": "src",
     "noEmit": false,
-    "isolatedModules": false,
-    "types": ["node", "electron"]
+    "types": ["node", "vitest/globals"]
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["dist", "src/**/*.test.ts"]
+  "exclude": ["dist", "test"]
 }


### PR DESCRIPTION
## Summary
- Adds the `@mergepilot/orchestrator` package with an in-process local orchestrator service and SQLite-backed persistence for workstreams, timeline events, plans, and agent runs.
- Wires Electron main/preload IPC handlers so the renderer can start/stop the local orchestrator, create/list workstreams, and append/read timeline events through the secure bridge.
- Updates the renderer shell to exercise persisted workstreams/events and documents the local orchestrator lifecycle, data location, schema, and IPC surface.
- Adds runtime validation and SQLite status constraints for persisted status fields.

Closes #14

## Verification
- `npm run verify`
- `node -e "import('@mergepilot/orchestrator').then(m => console.log(Object.keys(m).sort().join(',')))"`
- `git diff --check`
- `npm audit --omit=dev`
- Added-line static scan for hardcoded secrets and risky shell/eval patterns
- Markdown reference check for forbidden external references
- Independent review after validation hardening: pass/no blockers

## Notes
- Full Electron GUI launch could not be independently smoke-tested in this container because the environment is missing `libgtk-3.so.0`; build, package import, IPC unit tests, persistence tests, and existing smoke checks pass.
