### PR TITLE
feat: add canonical workstream model

### DIFF
--- a/apps/desktop/src/main/orchestrator-ipc.test.ts
+++ b/apps/desktop/src/main/orchestrator-ipc.test.ts
@@ -25,19 +25,63 @@ describe("orchestrator IPC handlers", () => {
     const orchestrator = {
       start: vi.fn(async () => undefined),
       stop: vi.fn(async () => undefined),
-      status: vi.fn(() => ({ state: "running", dataDir: "/tmp/data" })),
-      createWorkstream: vi.fn(() => ({ id: "ws-1", title: "IPC work", status: "active" })),
+      status: vi.fn(() => ({ state: "running" as const, dataDir: "/tmp/data", databasePath: "/tmp/data/mergepilot.sqlite3" })),
+      createWorkstream: vi.fn(() => ({
+        id: "ws-1",
+        title: "IPC work",
+        goal: "Exercise IPC workstream creation.",
+        repo: "ss-andrade/mergepilot",
+        createdBy: "renderer",
+        summary: null,
+        status: "draft" as const,
+        createdAt: "2026-05-01T00:00:00.000Z",
+        updatedAt: "2026-05-01T00:00:00.000Z"
+      })),
       listWorkstreams: vi.fn(() => []),
-      getWorkstream: vi.fn(() => ({ id: "ws-1", title: "IPC work" })),
-      appendEvent: vi.fn(() => ({ id: "evt-1", workstreamId: "ws-1", sequence: 1 })),
+      getWorkstream: vi.fn(() => ({
+        id: "ws-1",
+        title: "IPC work",
+        goal: "Exercise IPC workstream creation.",
+        repo: "ss-andrade/mergepilot",
+        createdBy: "renderer",
+        summary: null,
+        status: "draft" as const,
+        createdAt: "2026-05-01T00:00:00.000Z",
+        updatedAt: "2026-05-01T00:00:00.000Z"
+      })),
+      updateWorkstreamStatus: vi.fn(() => ({
+        id: "ws-1",
+        title: "IPC work",
+        goal: "Exercise IPC workstream creation.",
+        repo: "ss-andrade/mergepilot",
+        createdBy: "renderer",
+        summary: null,
+        status: "planning" as const,
+        createdAt: "2026-05-01T00:00:00.000Z",
+        updatedAt: "2026-05-01T00:01:00.000Z"
+      })),
+      appendEvent: vi.fn(() => ({
+        id: "evt-1",
+        workstreamId: "ws-1",
+        sequence: 1,
+        type: "ipc.event",
+        message: "IPC event",
+        payload: { ok: true },
+        createdAt: "2026-05-01T00:02:00.000Z"
+      })),
       listEvents: vi.fn(() => [])
     };
 
     registerOrchestratorIpcHandlers(ipc, orchestrator);
 
-    await expect(ipc.invoke("orchestrator:start")).resolves.toEqual({ state: "running", dataDir: "/tmp/data" });
+    await expect(ipc.invoke("orchestrator:start")).resolves.toMatchObject({ state: "running", dataDir: "/tmp/data" });
     await expect(
-      ipc.invoke("workstreams:create", { title: "IPC work", repositoryPath: "/tmp/repo" })
+      ipc.invoke("workstreams:create", {
+        title: "IPC work",
+        goal: "Exercise IPC workstream creation.",
+        repo: "ss-andrade/mergepilot",
+        createdBy: "renderer"
+      })
     ).resolves.toMatchObject({ id: "ws-1" });
     await ipc.invoke("events:append", {
       workstreamId: "ws-1",
@@ -45,10 +89,16 @@ describe("orchestrator IPC handlers", () => {
       message: "IPC event",
       payload: { ok: true }
     });
+    await expect(ipc.invoke("workstreams:update-status", { workstreamId: "ws-1", status: "planning" })).resolves.toMatchObject({
+      id: "ws-1",
+      status: "planning"
+    });
 
     expect(orchestrator.createWorkstream).toHaveBeenCalledWith({
       title: "IPC work",
-      repositoryPath: "/tmp/repo"
+      goal: "Exercise IPC workstream creation.",
+      repo: "ss-andrade/mergepilot",
+      createdBy: "renderer"
     });
     expect(orchestrator.appendEvent).toHaveBeenCalledWith({
       workstreamId: "ws-1",
@@ -56,6 +106,7 @@ describe("orchestrator IPC handlers", () => {
       message: "IPC event",
       payload: { ok: true }
     });
+    expect(orchestrator.updateWorkstreamStatus).toHaveBeenCalledWith("ws-1", "planning");
   });
 
   it("validates IPC input before calling services", async () => {
@@ -67,6 +118,7 @@ describe("orchestrator IPC handlers", () => {
       createWorkstream: vi.fn(),
       listWorkstreams: vi.fn(),
       getWorkstream: vi.fn(),
+      updateWorkstreamStatus: vi.fn(),
       appendEvent: vi.fn(),
       listEvents: vi.fn()
     };
@@ -74,8 +126,15 @@ describe("orchestrator IPC handlers", () => {
     registerOrchestratorIpcHandlers(ipc, orchestrator);
 
     await expect(ipc.invoke("workstreams:create", { title: "" })).rejects.toThrow(/title/i);
+    await expect(ipc.invoke("workstreams:create", {
+      title: "Needs goal",
+      repo: "ss-andrade/mergepilot",
+      createdBy: "renderer"
+    })).rejects.toThrow(/goal/i);
+    await expect(ipc.invoke("workstreams:update-status", { workstreamId: "ws-1", status: "active" })).rejects.toThrow(/status/i);
     await expect(ipc.invoke("events:list", { workstreamId: "../bad" })).rejects.toThrow(/workstreamId/i);
     expect(orchestrator.createWorkstream).not.toHaveBeenCalled();
+    expect(orchestrator.updateWorkstreamStatus).not.toHaveBeenCalled();
     expect(orchestrator.listEvents).not.toHaveBeenCalled();
   });
 });

--- a/apps/desktop/src/main/orchestrator-ipc.ts
+++ b/apps/desktop/src/main/orchestrator-ipc.ts
@@ -1,7 +1,8 @@
 import type {
   AppendWorkstreamEventInput,
   CreateWorkstreamInput,
-  LocalOrchestratorService
+  LocalOrchestratorService,
+  WorkstreamStatus
 } from "@mergepilot/orchestrator";
 
 export interface OrchestratorIpc {
@@ -22,6 +23,7 @@ export function registerOrchestratorIpcHandlers(
     | "createWorkstream"
     | "listWorkstreams"
     | "getWorkstream"
+    | "updateWorkstreamStatus"
     | "appendEvent"
     | "listEvents"
   >
@@ -49,6 +51,12 @@ export function registerOrchestratorIpcHandlers(
     return orchestrator.getWorkstream(id);
   });
 
+  ipc.handle("workstreams:update-status", (_event, rawInput) => {
+    const input = requireRecord(rawInput);
+    const id = parseIdInput(input.workstreamId, "workstreamId");
+    return orchestrator.updateWorkstreamStatus(id, parseWorkstreamStatus(input.status));
+  });
+
   ipc.handle("events:append", (_event, rawInput) => {
     return orchestrator.appendEvent(parseAppendEventInput(rawInput));
   });
@@ -62,14 +70,14 @@ export function registerOrchestratorIpcHandlers(
 function parseCreateWorkstreamInput(rawInput: unknown): CreateWorkstreamInput {
   const input = requireRecord(rawInput);
   const parsed: CreateWorkstreamInput = {
-    title: requireBoundedString(input.title, "title", 160)
+    title: requireBoundedString(input.title, "title", 160),
+    goal: requireBoundedString(input.goal, "goal", 5000),
+    repo: requireBoundedString(input.repo, "repo", 2048),
+    createdBy: requireBoundedString(input.createdBy, "createdBy", 160)
   };
 
-  if ("description" in input) {
-    parsed.description = optionalBoundedString(input.description, "description", 5000);
-  }
-  if ("repositoryPath" in input) {
-    parsed.repositoryPath = optionalBoundedString(input.repositoryPath, "repositoryPath", 2048);
+  if ("summary" in input) {
+    parsed.summary = optionalBoundedString(input.summary, "summary", 5000);
   }
 
   return parsed;
@@ -136,6 +144,27 @@ function requireEventType(value: unknown): string {
     throw new Error("type must be a valid event type.");
   }
   return type;
+}
+
+function parseWorkstreamStatus(value: unknown): WorkstreamStatus {
+  const status = requireBoundedString(value, "status", 40);
+  if (
+    ![
+      "draft",
+      "planning",
+      "awaiting_plan_approval",
+      "running",
+      "awaiting_user_input",
+      "awaiting_review",
+      "merge_ready",
+      "completed",
+      "failed",
+      "cancelled"
+    ].includes(status)
+  ) {
+    throw new Error("status must be a valid workstream status.");
+  }
+  return status as WorkstreamStatus;
 }
 
 function assertJsonCompatible(value: unknown): void {

--- a/apps/desktop/src/preload/preload.cts
+++ b/apps/desktop/src/preload/preload.cts
@@ -13,20 +13,36 @@ export interface OrchestratorStatus {
   databasePath: string;
 }
 
+export type WorkstreamStatus =
+  | "draft"
+  | "planning"
+  | "awaiting_plan_approval"
+  | "running"
+  | "awaiting_user_input"
+  | "awaiting_review"
+  | "merge_ready"
+  | "completed"
+  | "failed"
+  | "cancelled";
+
 export interface Workstream {
   id: string;
   title: string;
-  description: string | null;
-  repositoryPath: string | null;
-  status: "active" | "paused" | "completed" | "archived";
+  goal: string;
+  status: WorkstreamStatus;
+  repo: string;
+  createdBy: string;
+  summary: string | null;
   createdAt: string;
   updatedAt: string;
 }
 
 export interface CreateWorkstreamInput {
   title: string;
-  description?: string | null;
-  repositoryPath?: string | null;
+  goal: string;
+  repo: string;
+  createdBy: string;
+  summary?: string | null;
 }
 
 export interface WorkstreamEvent {
@@ -61,6 +77,7 @@ export interface MergePilotDesktopApi {
     create(input: CreateWorkstreamInput): Promise<Workstream>;
     list(): Promise<Workstream[]>;
     get(id: string): Promise<Workstream | null>;
+    updateStatus(id: string, status: WorkstreamStatus): Promise<Workstream>;
   };
   events: {
     append(input: AppendWorkstreamEventInput): Promise<WorkstreamEvent>;
@@ -82,7 +99,8 @@ const desktopApi: MergePilotDesktopApi = {
   workstreams: {
     create: (input) => ipcRenderer.invoke("workstreams:create", input),
     list: () => ipcRenderer.invoke("workstreams:list"),
-    get: (id) => ipcRenderer.invoke("workstreams:get", { workstreamId: id })
+    get: (id) => ipcRenderer.invoke("workstreams:get", { workstreamId: id }),
+    updateStatus: (id, status) => ipcRenderer.invoke("workstreams:update-status", { workstreamId: id, status })
   },
   events: {
     append: (input) => ipcRenderer.invoke("events:append", input),

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -44,8 +44,9 @@ interface TimelineState {
 
 interface WorkstreamFormState {
   title: string;
-  description: string;
-  repositoryPath: string;
+  goal: string;
+  repo: string;
+  summary: string;
 }
 
 const fallbackSections = [
@@ -78,8 +79,9 @@ const navItems = [
 
 const emptyForm: WorkstreamFormState = {
   title: "",
-  description: "",
-  repositoryPath: ""
+  goal: "",
+  repo: "",
+  summary: ""
 };
 
 function formatDate(value: string) {
@@ -90,9 +92,10 @@ function formatDate(value: string) {
 }
 
 function getStatusTone(status: Workstream["status"]) {
-  if (status === "active") return "success";
-  if (status === "paused") return "warning";
+  if (status === "running" || status === "merge_ready") return "success";
+  if (status === "awaiting_user_input" || status === "awaiting_review" || status === "awaiting_plan_approval") return "warning";
   if (status === "completed") return "accent";
+  if (status === "failed" || status === "cancelled") return "danger";
   return "muted";
 }
 
@@ -190,8 +193,10 @@ export function App() {
       const title = input?.title.trim() || `Workstream ${workstreams.length + 1}`;
       const created = await window.mergePilot.workstreams.create({
         title,
-        description: input?.description.trim() || "Created through the secure Electron bridge.",
-        repositoryPath: input?.repositoryPath.trim() || null
+        goal: input?.goal.trim() || "Coordinate and verify a local engineering goal through MergePilot.",
+        repo: input?.repo.trim() || "local/workspace",
+        createdBy: "renderer",
+        summary: input?.summary.trim() || "Created through the secure Electron bridge."
       });
       await window.mergePilot.events.append({
         workstreamId: created.id,
@@ -377,7 +382,7 @@ export function App() {
             </Badge>
             <p>
               {selectedWorkstream
-                ? selectedWorkstream.description ?? "This workstream is ready for local timeline capture."
+                ? selectedWorkstream.summary ?? selectedWorkstream.goal
                 : "Coordinator, build agents, PR checks, and human decisions land in this desktop surface."}
             </p>
           </div>
@@ -409,8 +414,8 @@ export function App() {
                         <span>{formatDate(workstream.updatedAt)}</span>
                       </div>
                       <h4>{workstream.title}</h4>
-                      <p>{workstream.description ?? "No description"}</p>
-                      {workstream.repositoryPath ? <code>{workstream.repositoryPath}</code> : null}
+                      <p>{workstream.summary ?? workstream.goal}</p>
+                      <code>{workstream.repo}</code>
                       <div className="mp-card__footer">
                         <Button variant="outline" onClick={() => void selectWorkstream(workstream.id)}>
                           View timeline
@@ -552,7 +557,7 @@ function NewWorkstreamDialog({
       <form onSubmit={onSubmit}>
         <DialogHeader>
           <DialogTitle>New workstream</DialogTitle>
-          <DialogDescription>Describe the goal and optional repository path to start local tracking.</DialogDescription>
+          <DialogDescription>Describe the goal and repository scope to start local tracking.</DialogDescription>
         </DialogHeader>
         <DialogBody className="mp-form-grid">
           <div>
@@ -566,22 +571,31 @@ function NewWorkstreamDialog({
             />
           </div>
           <div>
-            <Label htmlFor="workstream-description">Description</Label>
+            <Label htmlFor="workstream-goal">Goal</Label>
             <Textarea
-              id="workstream-description"
-              onChange={(event) => setFormState({ ...formState, description: event.target.value })}
+              id="workstream-goal"
+              onChange={(event) => setFormState({ ...formState, goal: event.target.value })}
               placeholder="What should agents coordinate, verify, and report?"
               rows={4}
-              value={formState.description}
+              value={formState.goal}
             />
           </div>
           <div>
-            <Label htmlFor="workstream-path">Repository path</Label>
+            <Label htmlFor="workstream-repo">Repository</Label>
             <Input
-              id="workstream-path"
-              onChange={(event) => setFormState({ ...formState, repositoryPath: event.target.value })}
-              placeholder="/path/to/repo"
-              value={formState.repositoryPath}
+              id="workstream-repo"
+              onChange={(event) => setFormState({ ...formState, repo: event.target.value })}
+              placeholder="ss-andrade/mergepilot"
+              value={formState.repo}
+            />
+          </div>
+          <div>
+            <Label htmlFor="workstream-summary">Summary</Label>
+            <Input
+              id="workstream-summary"
+              onChange={(event) => setFormState({ ...formState, summary: event.target.value })}
+              placeholder="Short visible summary"
+              value={formState.summary}
             />
           </div>
         </DialogBody>

--- a/apps/web/src/global.d.ts
+++ b/apps/web/src/global.d.ts
@@ -11,20 +11,36 @@ interface OrchestratorStatus {
   databasePath: string;
 }
 
+type WorkstreamStatus =
+  | "draft"
+  | "planning"
+  | "awaiting_plan_approval"
+  | "running"
+  | "awaiting_user_input"
+  | "awaiting_review"
+  | "merge_ready"
+  | "completed"
+  | "failed"
+  | "cancelled";
+
 interface Workstream {
   id: string;
   title: string;
-  description: string | null;
-  repositoryPath: string | null;
-  status: "active" | "paused" | "completed" | "archived";
+  goal: string;
+  status: WorkstreamStatus;
+  repo: string;
+  createdBy: string;
+  summary: string | null;
   createdAt: string;
   updatedAt: string;
 }
 
 interface CreateWorkstreamInput {
   title: string;
-  description?: string | null;
-  repositoryPath?: string | null;
+  goal: string;
+  repo: string;
+  createdBy: string;
+  summary?: string | null;
 }
 
 interface WorkstreamEvent {
@@ -59,6 +75,7 @@ interface MergePilotDesktopApi {
     create(input: CreateWorkstreamInput): Promise<Workstream>;
     list(): Promise<Workstream[]>;
     get(id: string): Promise<Workstream | null>;
+    updateStatus(id: string, status: WorkstreamStatus): Promise<Workstream>;
   };
   events: {
     append(input: AppendWorkstreamEventInput): Promise<WorkstreamEvent>;

--- a/docs/product-brief.md
+++ b/docs/product-brief.md
@@ -565,11 +565,10 @@ Agent notices repeated workflow
 Workstream
   id
   title
-  status
   goal
+  status
+  repo
   createdBy
-  repoScope
-  coordinatorAgentId
   summary
   createdAt
   updatedAt

--- a/packages/orchestrator/src/service.ts
+++ b/packages/orchestrator/src/service.ts
@@ -6,7 +6,8 @@ import {
   CreateWorkstreamInput,
   LocalOrchestratorService,
   OrchestratorStatus,
-  OrchestratorStore
+  OrchestratorStore,
+  WorkstreamStatus
 } from "./types.js";
 import { createSqliteOrchestratorStore } from "./sqlite-store.js";
 
@@ -53,6 +54,10 @@ export class InProcessLocalOrchestrator implements LocalOrchestratorService {
 
   getWorkstream(id: string) {
     return this.requireStore().getWorkstream(id);
+  }
+
+  updateWorkstreamStatus(id: string, nextStatus: WorkstreamStatus) {
+    return this.requireStore().updateWorkstreamStatus(id, nextStatus);
   }
 
   appendEvent(input: AppendWorkstreamEventInput) {

--- a/packages/orchestrator/src/sqlite-store.ts
+++ b/packages/orchestrator/src/sqlite-store.ts
@@ -20,7 +20,9 @@ import {
   requireEventType,
   requireId,
   requirePlanStatus,
-  requireString
+  requireString,
+  requireWorkstreamStatus,
+  assertWorkstreamStatusTransition
 } from "./validation.js";
 
 export interface SqliteStoreOptions {
@@ -28,8 +30,8 @@ export interface SqliteStoreOptions {
   databaseFileName?: string;
 }
 
-type WorkstreamRow = Omit<Workstream, "repositoryPath" | "createdAt" | "updatedAt"> & {
-  repository_path: string | null;
+type WorkstreamRow = Omit<Workstream, "createdBy" | "createdAt" | "updatedAt"> & {
+  created_by: string;
   created_at: string;
   updated_at: string;
 };
@@ -78,17 +80,19 @@ export class SqliteOrchestratorStore implements OrchestratorStore {
     const workstream: Workstream = {
       id: randomUUID(),
       title: requireString(input.title, "title", 160),
-      description: normalizeOptionalString(input.description, 5000),
-      repositoryPath: normalizeOptionalString(input.repositoryPath, 2048),
-      status: "active",
+      goal: requireString(input.goal, "goal", 5000),
+      status: "draft",
+      repo: requireString(input.repo, "repo", 2048),
+      createdBy: requireString(input.createdBy, "createdBy", 160),
+      summary: normalizeOptionalString(input.summary, 5000),
       createdAt: now,
       updatedAt: now
     };
 
     this.db
       .prepare(
-        `INSERT INTO workstreams (id, title, description, repository_path, status, created_at, updated_at)
-         VALUES (@id, @title, @description, @repositoryPath, @status, @createdAt, @updatedAt)`
+        `INSERT INTO workstreams (id, title, goal, status, repo, created_by, summary, created_at, updated_at)
+         VALUES (@id, @title, @goal, @status, @repo, @createdBy, @summary, @createdAt, @updatedAt)`
       )
       .run(workstream);
 
@@ -107,6 +111,28 @@ export class SqliteOrchestratorStore implements OrchestratorStore {
       | WorkstreamRow
       | undefined;
     return row ? mapWorkstreamRow(row) : null;
+  }
+
+  updateWorkstreamStatus(id: string, nextStatus: Workstream["status"]): Workstream {
+    const workstreamId = requireId(id);
+    const status = requireWorkstreamStatus(nextStatus);
+    const current = this.getWorkstream(workstreamId);
+    if (!current) {
+      throw new Error(`Workstream ${workstreamId} was not found.`);
+    }
+    assertWorkstreamStatusTransition(current.status, status);
+
+    if (current.status === status) {
+      return current;
+    }
+
+    const updatedAt = new Date().toISOString();
+    this.db.prepare("UPDATE workstreams SET status = ?, updated_at = ? WHERE id = ?").run(status, updatedAt, workstreamId);
+    return {
+      ...current,
+      status,
+      updatedAt
+    };
   }
 
   appendEvent(input: AppendWorkstreamEventInput): WorkstreamEvent {
@@ -247,13 +273,27 @@ export class SqliteOrchestratorStore implements OrchestratorStore {
   }
 
   private migrate(): void {
+    this.recreateLegacyWorkstreamSchema();
     this.db.exec(`
       CREATE TABLE IF NOT EXISTS workstreams (
         id TEXT PRIMARY KEY,
         title TEXT NOT NULL,
-        description TEXT,
-        repository_path TEXT,
-        status TEXT NOT NULL CHECK (status IN ('active', 'paused', 'completed', 'archived')),
+        goal TEXT NOT NULL,
+        status TEXT NOT NULL CHECK (status IN (
+          'draft',
+          'planning',
+          'awaiting_plan_approval',
+          'running',
+          'awaiting_user_input',
+          'awaiting_review',
+          'merge_ready',
+          'completed',
+          'failed',
+          'cancelled'
+        )),
+        repo TEXT NOT NULL,
+        created_by TEXT NOT NULL,
+        summary TEXT,
         created_at TEXT NOT NULL,
         updated_at TEXT NOT NULL
       );
@@ -301,6 +341,156 @@ export class SqliteOrchestratorStore implements OrchestratorStore {
         ON agent_runs(workstream_id);
     `);
   }
+
+  private recreateLegacyWorkstreamSchema(): void {
+    const columns = this.db.prepare("PRAGMA table_info(workstreams)").all() as Array<{ name: string }>;
+    if (columns.length === 0) {
+      return;
+    }
+
+    const columnNames = new Set(columns.map((column) => column.name));
+    const hasCanonicalColumns = ["goal", "repo", "created_by", "summary"].every((column) => columnNames.has(column));
+    if (hasCanonicalColumns) {
+      return;
+    }
+
+    const legacyWorkstreams = this.db.prepare("SELECT * FROM workstreams").all() as Array<Record<string, unknown>>;
+    const legacyEvents = this.readLegacyRows("workstream_events");
+    const legacyPlans = this.readLegacyRows("plans");
+    const legacyAgentRuns = this.readLegacyRows("agent_runs");
+
+    this.db.pragma("foreign_keys = OFF");
+    const migrateLegacyData = this.db.transaction(() => {
+      this.db.exec(`
+        DROP TABLE IF EXISTS agent_runs;
+        DROP TABLE IF EXISTS plans;
+        DROP TABLE IF EXISTS workstream_events;
+        DROP TABLE IF EXISTS workstreams;
+      `);
+
+      this.db.exec(`
+        CREATE TABLE workstreams (
+          id TEXT PRIMARY KEY,
+          title TEXT NOT NULL,
+          goal TEXT NOT NULL,
+          status TEXT NOT NULL CHECK (status IN (
+            'draft',
+            'planning',
+            'awaiting_plan_approval',
+            'running',
+            'awaiting_user_input',
+            'awaiting_review',
+            'merge_ready',
+            'completed',
+            'failed',
+            'cancelled'
+          )),
+          repo TEXT NOT NULL,
+          created_by TEXT NOT NULL,
+          summary TEXT,
+          created_at TEXT NOT NULL,
+          updated_at TEXT NOT NULL
+        );
+
+        CREATE TABLE workstream_events (
+          id TEXT PRIMARY KEY,
+          workstream_id TEXT NOT NULL REFERENCES workstreams(id) ON DELETE CASCADE,
+          sequence INTEGER NOT NULL,
+          type TEXT NOT NULL,
+          message TEXT NOT NULL,
+          payload_json TEXT,
+          created_at TEXT NOT NULL,
+          UNIQUE(workstream_id, sequence)
+        );
+
+        CREATE TABLE plans (
+          id TEXT PRIMARY KEY,
+          workstream_id TEXT NOT NULL REFERENCES workstreams(id) ON DELETE CASCADE,
+          title TEXT NOT NULL,
+          body TEXT NOT NULL,
+          status TEXT NOT NULL CHECK (status IN ('draft', 'approved', 'rejected', 'superseded')),
+          created_at TEXT NOT NULL,
+          updated_at TEXT NOT NULL
+        );
+
+        CREATE TABLE agent_runs (
+          id TEXT PRIMARY KEY,
+          workstream_id TEXT NOT NULL REFERENCES workstreams(id) ON DELETE CASCADE,
+          provider_id TEXT NOT NULL,
+          adapter_id TEXT,
+          role TEXT NOT NULL,
+          status TEXT NOT NULL CHECK (status IN ('queued', 'running', 'completed', 'failed', 'cancelled')),
+          goal TEXT NOT NULL,
+          started_at TEXT,
+          completed_at TEXT,
+          created_at TEXT NOT NULL,
+          updated_at TEXT NOT NULL
+        );
+      `);
+
+      const insertWorkstream = this.db.prepare(`
+        INSERT INTO workstreams (id, title, goal, status, repo, created_by, summary, created_at, updated_at)
+        VALUES (@id, @title, @goal, @status, @repo, @createdBy, @summary, @createdAt, @updatedAt)
+      `);
+      for (const row of legacyWorkstreams) {
+        const title = String(row.title ?? "Untitled workstream");
+        const summary = nullableString(row.description);
+        insertWorkstream.run({
+          id: String(row.id),
+          title,
+          goal: summary ?? title,
+          status: mapLegacyWorkstreamStatus(nullableString(row.status)),
+          repo: nullableString(row.repository_path) ?? "legacy/local-repository",
+          createdBy: "legacy",
+          summary,
+          createdAt: String(row.created_at ?? new Date().toISOString()),
+          updatedAt: String(row.updated_at ?? row.created_at ?? new Date().toISOString())
+        });
+      }
+
+      const insertEvent = this.db.prepare(`
+        INSERT INTO workstream_events (id, workstream_id, sequence, type, message, payload_json, created_at)
+        VALUES (@id, @workstream_id, @sequence, @type, @message, @payload_json, @created_at)
+      `);
+      for (const row of legacyEvents) {
+        insertEvent.run(row);
+      }
+
+      const insertPlan = this.db.prepare(`
+        INSERT INTO plans (id, workstream_id, title, body, status, created_at, updated_at)
+        VALUES (@id, @workstream_id, @title, @body, @status, @created_at, @updated_at)
+      `);
+      for (const row of legacyPlans) {
+        insertPlan.run(row);
+      }
+
+      const insertAgentRun = this.db.prepare(`
+        INSERT INTO agent_runs (
+          id, workstream_id, provider_id, adapter_id, role, status, goal, started_at, completed_at, created_at, updated_at
+        )
+        VALUES (
+          @id, @workstream_id, @provider_id, @adapter_id, @role, @status, @goal, @started_at, @completed_at, @created_at, @updated_at
+        )
+      `);
+      for (const row of legacyAgentRuns) {
+        insertAgentRun.run(row);
+      }
+    });
+
+    try {
+      migrateLegacyData();
+    } finally {
+      this.db.pragma("foreign_keys = ON");
+    }
+  }
+
+  private readLegacyRows(tableName: string): Array<Record<string, unknown>> {
+    const row = this.db.prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?").get(tableName);
+    if (!row) {
+      return [];
+    }
+    return this.db.prepare(`SELECT * FROM ${tableName}`).all() as Array<Record<string, unknown>>;
+  }
 }
 
 export function createSqliteOrchestratorStore(options: SqliteStoreOptions): SqliteOrchestratorStore {
@@ -311,9 +501,11 @@ function mapWorkstreamRow(row: WorkstreamRow): Workstream {
   return {
     id: row.id,
     title: row.title,
-    description: row.description,
-    repositoryPath: row.repository_path,
+    goal: row.goal,
     status: row.status,
+    repo: row.repo,
+    createdBy: row.created_by,
+    summary: row.summary,
     createdAt: row.created_at,
     updatedAt: row.updated_at
   };
@@ -357,4 +549,27 @@ function mapAgentRunRow(row: AgentRunRow): AgentRun {
     createdAt: row.created_at,
     updatedAt: row.updated_at
   };
+}
+
+function nullableString(value: unknown): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+  const trimmed = value.trim();
+  return trimmed ? trimmed : null;
+}
+
+function mapLegacyWorkstreamStatus(status: string | null): Workstream["status"] {
+  switch (status) {
+    case "completed":
+      return "completed";
+    case "paused":
+      return "awaiting_user_input";
+    case "archived":
+      return "cancelled";
+    case "active":
+      return "running";
+    default:
+      return "draft";
+  }
 }

--- a/packages/orchestrator/src/types.ts
+++ b/packages/orchestrator/src/types.ts
@@ -1,4 +1,14 @@
-export type WorkstreamStatus = "active" | "paused" | "completed" | "archived";
+export type WorkstreamStatus =
+  | "draft"
+  | "planning"
+  | "awaiting_plan_approval"
+  | "running"
+  | "awaiting_user_input"
+  | "awaiting_review"
+  | "merge_ready"
+  | "completed"
+  | "failed"
+  | "cancelled";
 export type PlanStatus = "draft" | "approved" | "rejected" | "superseded";
 export type AgentRunStatus = "queued" | "running" | "completed" | "failed" | "cancelled";
 export type OrchestratorState = "stopped" | "running";
@@ -6,17 +16,21 @@ export type OrchestratorState = "stopped" | "running";
 export interface Workstream {
   id: string;
   title: string;
-  description: string | null;
-  repositoryPath: string | null;
+  goal: string;
   status: WorkstreamStatus;
+  repo: string;
+  createdBy: string;
+  summary: string | null;
   createdAt: string;
   updatedAt: string;
 }
 
 export interface CreateWorkstreamInput {
   title: string;
-  description?: string | null;
-  repositoryPath?: string | null;
+  goal: string;
+  repo: string;
+  createdBy: string;
+  summary?: string | null;
 }
 
 export interface WorkstreamEvent {
@@ -80,6 +94,7 @@ export interface OrchestratorStore {
   createWorkstream(input: CreateWorkstreamInput): Workstream;
   listWorkstreams(): Workstream[];
   getWorkstream(id: string): Workstream | null;
+  updateWorkstreamStatus(id: string, nextStatus: WorkstreamStatus): Workstream;
   appendEvent(input: AppendWorkstreamEventInput): WorkstreamEvent;
   listEvents(workstreamId: string): WorkstreamEvent[];
   createPlan(input: CreatePlanInput): Plan;

--- a/packages/orchestrator/src/validation.ts
+++ b/packages/orchestrator/src/validation.ts
@@ -1,5 +1,29 @@
 const idPattern = /^[A-Za-z0-9][A-Za-z0-9_-]{0,127}$/;
 const eventTypePattern = /^[a-z][a-z0-9.:_-]{0,127}$/;
+const workstreamStatuses = new Set([
+  "draft",
+  "planning",
+  "awaiting_plan_approval",
+  "running",
+  "awaiting_user_input",
+  "awaiting_review",
+  "merge_ready",
+  "completed",
+  "failed",
+  "cancelled"
+]);
+const allowedWorkstreamTransitions: Record<string, Set<string>> = {
+  draft: new Set(["planning", "cancelled"]),
+  planning: new Set(["awaiting_plan_approval", "cancelled"]),
+  awaiting_plan_approval: new Set(["running", "cancelled"]),
+  running: new Set(["awaiting_user_input", "awaiting_review", "failed", "cancelled"]),
+  awaiting_user_input: new Set(["running", "cancelled"]),
+  awaiting_review: new Set(["merge_ready", "running", "failed", "cancelled"]),
+  merge_ready: new Set(["completed", "running", "failed", "cancelled"]),
+  completed: new Set([]),
+  failed: new Set(["cancelled"]),
+  cancelled: new Set([])
+};
 const planStatuses = new Set(["draft", "approved", "rejected", "superseded"]);
 const agentRunStatuses = new Set(["queued", "running", "completed", "failed", "cancelled"]);
 
@@ -51,6 +75,46 @@ export function requireEventType(value: string): string {
     throw new Error("type must be a valid event type.");
   }
   return trimmed;
+}
+
+export function requireWorkstreamStatus(
+  value: unknown
+):
+  | "draft"
+  | "planning"
+  | "awaiting_plan_approval"
+  | "running"
+  | "awaiting_user_input"
+  | "awaiting_review"
+  | "merge_ready"
+  | "completed"
+  | "failed"
+  | "cancelled" {
+  const status = requireString(value as string, "status", 40);
+  if (!workstreamStatuses.has(status)) {
+    throw new Error("status must be a valid workstream status.");
+  }
+  return status as
+    | "draft"
+    | "planning"
+    | "awaiting_plan_approval"
+    | "running"
+    | "awaiting_user_input"
+    | "awaiting_review"
+    | "merge_ready"
+    | "completed"
+    | "failed"
+    | "cancelled";
+}
+
+export function assertWorkstreamStatusTransition(currentStatus: string, nextStatus: string): void {
+  if (currentStatus === nextStatus) {
+    return;
+  }
+
+  if (!allowedWorkstreamTransitions[currentStatus]?.has(nextStatus)) {
+    throw new Error(`Invalid workstream status transition from ${currentStatus} to ${nextStatus}.`);
+  }
 }
 
 export function requirePlanStatus(value: unknown): "draft" | "approved" | "rejected" | "superseded" {

--- a/packages/orchestrator/test/persistence.test.ts
+++ b/packages/orchestrator/test/persistence.test.ts
@@ -1,6 +1,7 @@
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import Database from "better-sqlite3";
 import { afterEach, describe, expect, it } from "vitest";
 import { createSqliteOrchestratorStore } from "../src/index.js";
 
@@ -23,8 +24,10 @@ describe("SqliteOrchestratorStore", () => {
 
     const created = first.createWorkstream({
       title: "Add orchestrator foundation",
-      repositoryPath: "/tmp/mergepilot",
-      description: "Track local work and event history."
+      goal: "Track local work and event history.",
+      repo: "ss-andrade/mergepilot",
+      createdBy: "hermes",
+      summary: "Build the local orchestration model."
     });
     first.close();
 
@@ -34,18 +37,190 @@ describe("SqliteOrchestratorStore", () => {
       expect.objectContaining({
         id: created.id,
         title: "Add orchestrator foundation",
-        repositoryPath: "/tmp/mergepilot",
-        status: "active"
+        goal: "Track local work and event history.",
+        repo: "ss-andrade/mergepilot",
+        createdBy: "hermes",
+        summary: "Build the local orchestration model.",
+        status: "draft"
       })
     ]);
-    expect(second.getWorkstream(created.id)).toMatchObject({ id: created.id });
+    expect(second.getWorkstream(created.id)).toMatchObject({
+      id: created.id,
+      title: "Add orchestrator foundation",
+      goal: "Track local work and event history.",
+      repo: "ss-andrade/mergepilot",
+      createdBy: "hermes",
+      summary: "Build the local orchestration model.",
+      status: "draft",
+      createdAt: expect.any(String),
+      updatedAt: expect.any(String)
+    });
     second.close();
+  });
+
+  it("migrates legacy workstream data without dropping linked records", async () => {
+    const dataDir = await createTempDir();
+    const databasePath = path.join(dataDir, "mergepilot.sqlite3");
+    const legacy = new Database(databasePath);
+    legacy.exec(`
+      PRAGMA foreign_keys = ON;
+      CREATE TABLE workstreams (
+        id TEXT PRIMARY KEY,
+        title TEXT NOT NULL,
+        description TEXT,
+        repository_path TEXT,
+        status TEXT NOT NULL CHECK (status IN ('active', 'paused', 'completed', 'archived')),
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+      );
+      CREATE TABLE workstream_events (
+        id TEXT PRIMARY KEY,
+        workstream_id TEXT NOT NULL REFERENCES workstreams(id) ON DELETE CASCADE,
+        sequence INTEGER NOT NULL,
+        type TEXT NOT NULL,
+        message TEXT NOT NULL,
+        payload_json TEXT,
+        created_at TEXT NOT NULL,
+        UNIQUE(workstream_id, sequence)
+      );
+      CREATE TABLE plans (
+        id TEXT PRIMARY KEY,
+        workstream_id TEXT NOT NULL REFERENCES workstreams(id) ON DELETE CASCADE,
+        title TEXT NOT NULL,
+        body TEXT NOT NULL,
+        status TEXT NOT NULL CHECK (status IN ('draft', 'approved', 'rejected', 'superseded')),
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+      );
+      CREATE TABLE agent_runs (
+        id TEXT PRIMARY KEY,
+        workstream_id TEXT NOT NULL REFERENCES workstreams(id) ON DELETE CASCADE,
+        provider_id TEXT NOT NULL,
+        adapter_id TEXT,
+        role TEXT NOT NULL,
+        status TEXT NOT NULL CHECK (status IN ('queued', 'running', 'completed', 'failed', 'cancelled')),
+        goal TEXT NOT NULL,
+        started_at TEXT,
+        completed_at TEXT,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+      );
+    `);
+    legacy.prepare(`
+      INSERT INTO workstreams (id, title, description, repository_path, status, created_at, updated_at)
+      VALUES ('legacy-ws', 'Legacy work', 'Legacy description', '/tmp/repo', 'active', '2026-05-01T00:00:00.000Z', '2026-05-01T00:00:00.000Z')
+    `).run();
+    legacy.prepare(`
+      INSERT INTO workstream_events (id, workstream_id, sequence, type, message, payload_json, created_at)
+      VALUES ('legacy-event', 'legacy-ws', 1, 'workstream.created', 'Created before migration', '{"ok":true}', '2026-05-01T00:00:01.000Z')
+    `).run();
+    legacy.prepare(`
+      INSERT INTO plans (id, workstream_id, title, body, status, created_at, updated_at)
+      VALUES ('legacy-plan', 'legacy-ws', 'Legacy plan', 'Plan body', 'draft', '2026-05-01T00:00:02.000Z', '2026-05-01T00:00:02.000Z')
+    `).run();
+    legacy.prepare(`
+      INSERT INTO agent_runs (id, workstream_id, provider_id, adapter_id, role, status, goal, started_at, completed_at, created_at, updated_at)
+      VALUES ('legacy-run', 'legacy-ws', 'codex', NULL, 'build', 'queued', 'Run goal', NULL, NULL, '2026-05-01T00:00:03.000Z', '2026-05-01T00:00:03.000Z')
+    `).run();
+    legacy.close();
+
+    const migrated = createSqliteOrchestratorStore({ dataDir });
+
+    expect(migrated.getWorkstream("legacy-ws")).toMatchObject({
+      id: "legacy-ws",
+      title: "Legacy work",
+      goal: "Legacy description",
+      repo: "/tmp/repo",
+      createdBy: "legacy",
+      summary: "Legacy description",
+      status: "running"
+    });
+    expect(migrated.listEvents("legacy-ws")).toEqual([expect.objectContaining({ id: "legacy-event" })]);
+    expect(migrated.listPlans("legacy-ws")).toEqual([expect.objectContaining({ id: "legacy-plan" })]);
+    expect(migrated.listAgentRuns("legacy-ws")).toEqual([expect.objectContaining({ id: "legacy-run" })]);
+    migrated.close();
+  });
+
+  it("creates canonical workstreams and validates status transitions", async () => {
+    const dataDir = await createTempDir();
+    const store = createSqliteOrchestratorStore({ dataDir });
+    const created = store.createWorkstream({
+      title: "Canonical model",
+      goal: "Exercise issue two behavior.",
+      repo: "ss-andrade/mergepilot",
+      createdBy: "hermes"
+    });
+
+    expect(created).toEqual({
+      id: expect.any(String),
+      title: "Canonical model",
+      goal: "Exercise issue two behavior.",
+      repo: "ss-andrade/mergepilot",
+      createdBy: "hermes",
+      summary: null,
+      status: "draft",
+      createdAt: expect.any(String),
+      updatedAt: created.createdAt
+    });
+
+    const planning = store.updateWorkstreamStatus(created.id, "planning");
+    expect(planning).toMatchObject({
+      id: created.id,
+      status: "planning",
+      createdAt: created.createdAt,
+      updatedAt: expect.any(String)
+    });
+    expect(new Date(planning.updatedAt).getTime()).toBeGreaterThanOrEqual(new Date(created.updatedAt).getTime());
+
+    expect(store.updateWorkstreamStatus(created.id, "awaiting_plan_approval")).toMatchObject({
+      status: "awaiting_plan_approval"
+    });
+    expect(store.updateWorkstreamStatus(created.id, "running")).toMatchObject({ status: "running" });
+    expect(store.updateWorkstreamStatus(created.id, "awaiting_user_input")).toMatchObject({
+      status: "awaiting_user_input"
+    });
+    expect(store.updateWorkstreamStatus(created.id, "running")).toMatchObject({ status: "running" });
+    expect(store.updateWorkstreamStatus(created.id, "awaiting_review")).toMatchObject({ status: "awaiting_review" });
+    expect(store.updateWorkstreamStatus(created.id, "merge_ready")).toMatchObject({ status: "merge_ready" });
+    expect(store.updateWorkstreamStatus(created.id, "completed")).toMatchObject({ status: "completed" });
+
+    expect(() => store.updateWorkstreamStatus(created.id, "running")).toThrow(/invalid workstream status transition/i);
+    expect(() => store.updateWorkstreamStatus(created.id, "active" as never)).toThrow(/valid workstream status/i);
+    store.close();
+  });
+
+  it("rejects invalid workstream transitions without changing persisted status", async () => {
+    const dataDir = await createTempDir();
+    const store = createSqliteOrchestratorStore({ dataDir });
+    const workstream = store.createWorkstream({
+      title: "Transition validation",
+      goal: "Reject impossible jumps.",
+      repo: "ss-andrade/mergepilot",
+      createdBy: "hermes"
+    });
+
+    expect(store.updateWorkstreamStatus(workstream.id, "planning")).toMatchObject({ status: "planning" });
+    expect(() => store.updateWorkstreamStatus(workstream.id, "merge_ready")).toThrow(
+      /invalid workstream status transition/i
+    );
+    expect(store.getWorkstream(workstream.id)).toMatchObject({ status: "planning" });
+
+    expect(store.updateWorkstreamStatus(workstream.id, "cancelled")).toMatchObject({ status: "cancelled" });
+    expect(() => store.updateWorkstreamStatus(workstream.id, "running")).toThrow(
+      /invalid workstream status transition/i
+    );
+    store.close();
   });
 
   it("appends and reads ordered timeline events with structured payloads", async () => {
     const dataDir = await createTempDir();
     const store = createSqliteOrchestratorStore({ dataDir });
-    const workstream = store.createWorkstream({ title: "Timeline coverage" });
+    const workstream = store.createWorkstream({
+      title: "Timeline coverage",
+      goal: "Capture ordered timeline events.",
+      repo: "ss-andrade/mergepilot",
+      createdBy: "hermes"
+    });
 
     const first = store.appendEvent({
       workstreamId: workstream.id,
@@ -77,7 +252,12 @@ describe("SqliteOrchestratorStore", () => {
   it("creates plans and agent runs linked to a workstream", async () => {
     const dataDir = await createTempDir();
     const store = createSqliteOrchestratorStore({ dataDir });
-    const workstream = store.createWorkstream({ title: "Agent run coverage" });
+    const workstream = store.createWorkstream({
+      title: "Agent run coverage",
+      goal: "Create linked plans and runs.",
+      repo: "ss-andrade/mergepilot",
+      createdBy: "hermes"
+    });
 
     const plan = store.createPlan({
       workstreamId: workstream.id,
@@ -101,7 +281,12 @@ describe("SqliteOrchestratorStore", () => {
   it("rejects invalid plan and agent run statuses at runtime", async () => {
     const dataDir = await createTempDir();
     const store = createSqliteOrchestratorStore({ dataDir });
-    const workstream = store.createWorkstream({ title: "Runtime validation" });
+    const workstream = store.createWorkstream({
+      title: "Runtime validation",
+      goal: "Validate child records.",
+      repo: "ss-andrade/mergepilot",
+      createdBy: "hermes"
+    });
 
     expect(() => store.createPlan({
       workstreamId: workstream.id,

--- a/packages/orchestrator/test/service.test.ts
+++ b/packages/orchestrator/test/service.test.ts
@@ -26,14 +26,32 @@ describe("LocalOrchestratorService", () => {
     await orchestrator.start();
     expect(orchestrator.status()).toMatchObject({ state: "running", dataDir });
 
-    const workstream = orchestrator.createWorkstream({ title: "Service workstream" });
+    const workstream = orchestrator.createWorkstream({
+      title: "Service workstream",
+      goal: "Exercise service behavior.",
+      repo: "ss-andrade/mergepilot",
+      createdBy: "hermes"
+    });
+    expect(orchestrator.updateWorkstreamStatus(workstream.id, "planning")).toMatchObject({ status: "planning" });
     orchestrator.appendEvent({
       workstreamId: workstream.id,
       type: "service.ready",
       message: "Service ready"
     });
 
-    expect(orchestrator.listWorkstreams()).toEqual([expect.objectContaining({ id: workstream.id })]);
+    expect(orchestrator.listWorkstreams()).toEqual([
+      expect.objectContaining({
+        id: workstream.id,
+        goal: "Exercise service behavior.",
+        repo: "ss-andrade/mergepilot",
+        createdBy: "hermes",
+        status: "planning"
+      })
+    ]);
+    expect(orchestrator.getWorkstream(workstream.id)).toMatchObject({
+      id: workstream.id,
+      title: "Service workstream"
+    });
     expect(orchestrator.listEvents(workstream.id)).toEqual([
       expect.objectContaining({ type: "service.ready" })
     ]);

--- a/tests/runtime/renderer.spec.ts
+++ b/tests/runtime/renderer.spec.ts
@@ -48,9 +48,11 @@ test("web renderer runs against a mocked mergePilot bridge", async ({ page }) =>
           const created: Workstream = {
             id: `ws-${workstreams.length + 1}`,
             title: input.title,
-            description: input.description ?? null,
-            repositoryPath: input.repositoryPath ?? null,
-            status: "active",
+            goal: input.goal,
+            repo: input.repo,
+            createdBy: input.createdBy,
+            summary: input.summary ?? null,
+            status: "draft",
             createdAt: now,
             updatedAt: now
           };
@@ -88,7 +90,8 @@ test("web renderer runs against a mocked mergePilot bridge", async ({ page }) =>
 
   await page.getByRole("button", { name: "New Workstream" }).click();
   await page.getByLabel("Title").fill("Workstream 1");
-  await page.getByLabel("Description").fill("Created through the secure Electron bridge.");
+  await page.getByLabel("Goal").fill("Created through the secure Electron bridge.");
+  await page.getByLabel("Repository").fill("ss-andrade/mergepilot");
   await page.getByRole("button", { name: "Create workstream" }).click();
 
   await expect(page.getByRole("heading", { level: 2, name: "Workstream 1" })).toBeVisible();


### PR DESCRIPTION
## Summary
- Adds the canonical Workstream model with `id`, `title`, `goal`, `status`, `repo`, `createdBy`, `summary`, `createdAt`, and `updatedAt`.
- Adds validated workstream creation, retrieval/listing, and status transitions across orchestrator persistence/service APIs.
- Migrates legacy local workstream databases into the canonical schema while preserving linked events, plans, and agent runs.
- Updates desktop IPC, preload, renderer types, renderer mocks, and product docs to use the canonical model.

## Verification
- [x] `npm run test -w @mergepilot/orchestrator -- test/persistence.test.ts test/service.test.ts`
- [x] `npm run typecheck`
- [x] `npm run test`
- [x] `npm run build -w @mergepilot/web`
- [x] `npm run test:e2e:web`
- [x] `npm run verify`
- [x] `npm run test:e2e:electron` (command exited 0; Electron runtime test skipped by environment preflight and Node ABI was rebuilt after)
- [x] Independent review completed with no blocking findings
- [x] Secret-like diff scan: 0 matches

Closes #2
