### PR TITLE
feat: add workstream event timeline model

### DIFF
--- a/apps/desktop/src/main/orchestrator-ipc.test.ts
+++ b/apps/desktop/src/main/orchestrator-ipc.test.ts
@@ -64,7 +64,7 @@ describe("orchestrator IPC handlers", () => {
         id: "evt-1",
         workstreamId: "ws-1",
         sequence: 1,
-        type: "ipc.event",
+        type: "user_message",
         message: "IPC event",
         payload: { ok: true },
         createdAt: "2026-05-01T00:02:00.000Z"
@@ -85,7 +85,7 @@ describe("orchestrator IPC handlers", () => {
     ).resolves.toMatchObject({ id: "ws-1" });
     await ipc.invoke("events:append", {
       workstreamId: "ws-1",
-      type: "ipc.event",
+      type: "user_message",
       message: "IPC event",
       payload: { ok: true }
     });
@@ -102,7 +102,7 @@ describe("orchestrator IPC handlers", () => {
     });
     expect(orchestrator.appendEvent).toHaveBeenCalledWith({
       workstreamId: "ws-1",
-      type: "ipc.event",
+      type: "user_message",
       message: "IPC event",
       payload: { ok: true }
     });
@@ -132,9 +132,21 @@ describe("orchestrator IPC handlers", () => {
       createdBy: "renderer"
     })).rejects.toThrow(/goal/i);
     await expect(ipc.invoke("workstreams:update-status", { workstreamId: "ws-1", status: "active" })).rejects.toThrow(/status/i);
+    await expect(
+      ipc.invoke("events:append", { workstreamId: "ws-1", type: "workstream.created", message: "Invalid event" })
+    ).rejects.toThrow(/event type/i);
+    await expect(
+      ipc.invoke("events:append", {
+        workstreamId: "ws-1",
+        type: "command_ran",
+        message: "Invalid payload",
+        payload: { elided: undefined }
+      })
+    ).rejects.toThrow(/payload/i);
     await expect(ipc.invoke("events:list", { workstreamId: "../bad" })).rejects.toThrow(/workstreamId/i);
     expect(orchestrator.createWorkstream).not.toHaveBeenCalled();
     expect(orchestrator.updateWorkstreamStatus).not.toHaveBeenCalled();
+    expect(orchestrator.appendEvent).not.toHaveBeenCalled();
     expect(orchestrator.listEvents).not.toHaveBeenCalled();
   });
 });

--- a/apps/desktop/src/main/orchestrator-ipc.ts
+++ b/apps/desktop/src/main/orchestrator-ipc.ts
@@ -2,8 +2,12 @@ import type {
   AppendWorkstreamEventInput,
   CreateWorkstreamInput,
   LocalOrchestratorService,
+  WorkstreamEventType,
   WorkstreamStatus
 } from "@mergepilot/orchestrator";
+import { WORKSTREAM_EVENT_TYPES } from "@mergepilot/orchestrator";
+
+const workstreamEventTypes = new Set<string>(WORKSTREAM_EVENT_TYPES);
 
 export interface OrchestratorIpc {
   handle(channel: string, listener: (event: unknown, ...args: unknown[]) => unknown): void;
@@ -138,12 +142,12 @@ function optionalBoundedString(value: unknown, field: string, maxLength: number)
   return requireBoundedString(value, field, maxLength);
 }
 
-function requireEventType(value: unknown): string {
+function requireEventType(value: unknown): WorkstreamEventType {
   const type = requireBoundedString(value, "type", 128);
-  if (!/^[a-z][a-z0-9.:_-]{0,127}$/.test(type)) {
+  if (!workstreamEventTypes.has(type)) {
     throw new Error("type must be a valid event type.");
   }
-  return type;
+  return type as WorkstreamEventType;
 }
 
 function parseWorkstreamStatus(value: unknown): WorkstreamStatus {
@@ -168,9 +172,40 @@ function parseWorkstreamStatus(value: unknown): WorkstreamStatus {
 }
 
 function assertJsonCompatible(value: unknown): void {
-  try {
-    JSON.stringify(value);
-  } catch {
+  if (!isJsonCompatible(value, new Set())) {
     throw new Error("payload must be JSON serializable.");
   }
+}
+
+function isJsonCompatible(value: unknown, seen: Set<object>): boolean {
+  if (value === null) {
+    return true;
+  }
+
+  switch (typeof value) {
+    case "string":
+    case "boolean":
+      return true;
+    case "number":
+      return Number.isFinite(value);
+    case "object":
+      break;
+    default:
+      return false;
+  }
+
+  if (seen.has(value)) {
+    return false;
+  }
+  seen.add(value);
+
+  if (Array.isArray(value)) {
+    return value.every((item) => isJsonCompatible(item, seen));
+  }
+
+  if (Object.getPrototypeOf(value) !== Object.prototype) {
+    return false;
+  }
+
+  return Object.values(value as Record<string, unknown>).every((item) => isJsonCompatible(item, seen));
 }

--- a/apps/desktop/src/preload/preload.cts
+++ b/apps/desktop/src/preload/preload.cts
@@ -24,6 +24,23 @@ export type WorkstreamStatus =
   | "completed"
   | "failed"
   | "cancelled";
+export type WorkstreamEventType =
+  | "user_message"
+  | "coordinator_message"
+  | "plan_created"
+  | "plan_approved"
+  | "agent_started"
+  | "agent_completed"
+  | "command_ran"
+  | "commit_created"
+  | "branch_pushed"
+  | "pr_opened"
+  | "ci_started"
+  | "ci_passed"
+  | "ci_failed"
+  | "review_summary_created"
+  | "human_action_required"
+  | "workstream_completed";
 
 export interface Workstream {
   id: string;
@@ -49,7 +66,7 @@ export interface WorkstreamEvent {
   id: string;
   workstreamId: string;
   sequence: number;
-  type: string;
+  type: WorkstreamEventType;
   message: string;
   payload: unknown | null;
   createdAt: string;
@@ -57,7 +74,7 @@ export interface WorkstreamEvent {
 
 export interface AppendWorkstreamEventInput {
   workstreamId: string;
-  type: string;
+  type: WorkstreamEventType;
   message: string;
   payload?: unknown;
 }

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -200,9 +200,9 @@ export function App() {
       });
       await window.mergePilot.events.append({
         workstreamId: created.id,
-        type: "workstream.created",
+        type: "user_message",
         message: "Workstream created from renderer",
-        payload: { surface: "web" }
+        payload: { surface: "web", action: "workstream_created" }
       });
       setFormState(emptyForm);
       setNewWorkstreamOpen(false);
@@ -217,9 +217,9 @@ export function App() {
     try {
       await window.mergePilot.events.append({
         workstreamId,
-        type: "timeline.note",
+        type: "coordinator_message",
         message: "Timeline note appended from renderer",
-        payload: { surface: "web" }
+        payload: { surface: "web", action: "timeline_note" }
       });
       setTimeline({
         selectedWorkstreamId: workstreamId,

--- a/apps/web/src/global.d.ts
+++ b/apps/web/src/global.d.ts
@@ -22,6 +22,23 @@ type WorkstreamStatus =
   | "completed"
   | "failed"
   | "cancelled";
+type WorkstreamEventType =
+  | "user_message"
+  | "coordinator_message"
+  | "plan_created"
+  | "plan_approved"
+  | "agent_started"
+  | "agent_completed"
+  | "command_ran"
+  | "commit_created"
+  | "branch_pushed"
+  | "pr_opened"
+  | "ci_started"
+  | "ci_passed"
+  | "ci_failed"
+  | "review_summary_created"
+  | "human_action_required"
+  | "workstream_completed";
 
 interface Workstream {
   id: string;
@@ -47,7 +64,7 @@ interface WorkstreamEvent {
   id: string;
   workstreamId: string;
   sequence: number;
-  type: string;
+  type: WorkstreamEventType;
   message: string;
   payload: unknown | null;
   createdAt: string;
@@ -55,7 +72,7 @@ interface WorkstreamEvent {
 
 interface AppendWorkstreamEventInput {
   workstreamId: string;
-  type: string;
+  type: WorkstreamEventType;
   message: string;
   payload?: unknown;
 }

--- a/packages/orchestrator/src/index.ts
+++ b/packages/orchestrator/src/index.ts
@@ -21,5 +21,7 @@ export type {
   PlanStatus,
   Workstream,
   WorkstreamEvent,
+  WorkstreamEventType,
   WorkstreamStatus
 } from "./types.js";
+export { WORKSTREAM_EVENT_TYPES } from "./types.js";

--- a/packages/orchestrator/src/sqlite-store.ts
+++ b/packages/orchestrator/src/sqlite-store.ts
@@ -11,7 +11,9 @@ import {
   OrchestratorStore,
   Plan,
   Workstream,
-  WorkstreamEvent
+  WorkstreamEvent,
+  WORKSTREAM_EVENT_TYPES,
+  WorkstreamEventType
 } from "./types.js";
 import {
   assertJsonCompatible,
@@ -60,6 +62,8 @@ type AgentRunRow = Omit<
   created_at: string;
   updated_at: string;
 };
+
+const eventTypeSqlList = WORKSTREAM_EVENT_TYPES.map((type) => `'${type}'`).join(", ");
 
 export class SqliteOrchestratorStore implements OrchestratorStore {
   readonly databasePath: string;
@@ -302,7 +306,7 @@ export class SqliteOrchestratorStore implements OrchestratorStore {
         id TEXT PRIMARY KEY,
         workstream_id TEXT NOT NULL REFERENCES workstreams(id) ON DELETE CASCADE,
         sequence INTEGER NOT NULL,
-        type TEXT NOT NULL,
+        type TEXT NOT NULL CHECK (type IN (${eventTypeSqlList})),
         message TEXT NOT NULL,
         payload_json TEXT,
         created_at TEXT NOT NULL,
@@ -340,6 +344,12 @@ export class SqliteOrchestratorStore implements OrchestratorStore {
       CREATE INDEX IF NOT EXISTS idx_agent_runs_workstream
         ON agent_runs(workstream_id);
     `);
+    this.ensureWorkstreamEventsSchema();
+    this.db.exec(`
+      CREATE INDEX IF NOT EXISTS idx_workstream_events_workstream_sequence
+        ON workstream_events(workstream_id, sequence);
+    `);
+    this.createEventImmutabilityTriggers();
   }
 
   private recreateLegacyWorkstreamSchema(): void {
@@ -396,7 +406,7 @@ export class SqliteOrchestratorStore implements OrchestratorStore {
           id TEXT PRIMARY KEY,
           workstream_id TEXT NOT NULL REFERENCES workstreams(id) ON DELETE CASCADE,
           sequence INTEGER NOT NULL,
-          type TEXT NOT NULL,
+          type TEXT NOT NULL CHECK (type IN (${eventTypeSqlList})),
           message TEXT NOT NULL,
           payload_json TEXT,
           created_at TEXT NOT NULL,
@@ -453,6 +463,7 @@ export class SqliteOrchestratorStore implements OrchestratorStore {
         VALUES (@id, @workstream_id, @sequence, @type, @message, @payload_json, @created_at)
       `);
       for (const row of legacyEvents) {
+        row.type = mapLegacyEventType(row.type);
         insertEvent.run(row);
       }
 
@@ -490,6 +501,67 @@ export class SqliteOrchestratorStore implements OrchestratorStore {
       return [];
     }
     return this.db.prepare(`SELECT * FROM ${tableName}`).all() as Array<Record<string, unknown>>;
+  }
+
+  private ensureWorkstreamEventsSchema(): void {
+    const table = this.db
+      .prepare("SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'workstream_events'")
+      .get() as { sql: string } | undefined;
+    if (!table || table.sql.includes("CHECK (type IN")) {
+      return;
+    }
+
+    const rows = this.db.prepare("SELECT * FROM workstream_events ORDER BY workstream_id, sequence").all() as Array<
+      Record<string, unknown>
+    >;
+
+    const recreateEvents = this.db.transaction(() => {
+      this.db.exec(`
+        DROP TRIGGER IF EXISTS trg_workstream_events_no_update;
+        DROP TRIGGER IF EXISTS trg_workstream_events_no_delete;
+        DROP TABLE workstream_events;
+        CREATE TABLE workstream_events (
+          id TEXT PRIMARY KEY,
+          workstream_id TEXT NOT NULL REFERENCES workstreams(id) ON DELETE CASCADE,
+          sequence INTEGER NOT NULL,
+          type TEXT NOT NULL CHECK (type IN (${eventTypeSqlList})),
+          message TEXT NOT NULL,
+          payload_json TEXT,
+          created_at TEXT NOT NULL,
+          UNIQUE(workstream_id, sequence)
+        );
+      `);
+
+      const insertEvent = this.db.prepare(`
+        INSERT INTO workstream_events (id, workstream_id, sequence, type, message, payload_json, created_at)
+        VALUES (@id, @workstream_id, @sequence, @type, @message, @payload_json, @created_at)
+      `);
+
+      for (const row of rows) {
+        insertEvent.run({
+          ...row,
+          type: mapLegacyEventType(row.type)
+        });
+      }
+    });
+
+    recreateEvents();
+  }
+
+  private createEventImmutabilityTriggers(): void {
+    this.db.exec(`
+      CREATE TRIGGER IF NOT EXISTS trg_workstream_events_no_update
+      BEFORE UPDATE ON workstream_events
+      BEGIN
+        SELECT RAISE(ABORT, 'workstream_events are immutable');
+      END;
+
+      CREATE TRIGGER IF NOT EXISTS trg_workstream_events_no_delete
+      BEFORE DELETE ON workstream_events
+      BEGIN
+        SELECT RAISE(ABORT, 'workstream_events are immutable');
+      END;
+    `);
   }
 }
 
@@ -571,5 +643,26 @@ function mapLegacyWorkstreamStatus(status: string | null): Workstream["status"] 
       return "running";
     default:
       return "draft";
+  }
+}
+
+function mapLegacyEventType(value: unknown): WorkstreamEventType {
+  if (typeof value === "string" && (WORKSTREAM_EVENT_TYPES as readonly string[]).includes(value)) {
+    return value as WorkstreamEventType;
+  }
+
+  switch (value) {
+    case "agent.run.started":
+      return "agent_started";
+    case "agent.run.completed":
+      return "agent_completed";
+    case "plan.created":
+      return "plan_created";
+    case "plan.approved":
+      return "plan_approved";
+    case "workstream.completed":
+      return "workstream_completed";
+    default:
+      return "user_message";
   }
 }

--- a/packages/orchestrator/src/types.ts
+++ b/packages/orchestrator/src/types.ts
@@ -12,6 +12,25 @@ export type WorkstreamStatus =
 export type PlanStatus = "draft" | "approved" | "rejected" | "superseded";
 export type AgentRunStatus = "queued" | "running" | "completed" | "failed" | "cancelled";
 export type OrchestratorState = "stopped" | "running";
+export const WORKSTREAM_EVENT_TYPES = [
+  "user_message",
+  "coordinator_message",
+  "plan_created",
+  "plan_approved",
+  "agent_started",
+  "agent_completed",
+  "command_ran",
+  "commit_created",
+  "branch_pushed",
+  "pr_opened",
+  "ci_started",
+  "ci_passed",
+  "ci_failed",
+  "review_summary_created",
+  "human_action_required",
+  "workstream_completed"
+] as const;
+export type WorkstreamEventType = (typeof WORKSTREAM_EVENT_TYPES)[number];
 
 export interface Workstream {
   id: string;
@@ -37,7 +56,7 @@ export interface WorkstreamEvent {
   id: string;
   workstreamId: string;
   sequence: number;
-  type: string;
+  type: WorkstreamEventType;
   message: string;
   payload: unknown | null;
   createdAt: string;
@@ -45,7 +64,7 @@ export interface WorkstreamEvent {
 
 export interface AppendWorkstreamEventInput {
   workstreamId: string;
-  type: string;
+  type: WorkstreamEventType;
   message: string;
   payload?: unknown;
 }

--- a/packages/orchestrator/src/validation.ts
+++ b/packages/orchestrator/src/validation.ts
@@ -1,5 +1,7 @@
+import { WORKSTREAM_EVENT_TYPES, WorkstreamEventType } from "./types.js";
+
 const idPattern = /^[A-Za-z0-9][A-Za-z0-9_-]{0,127}$/;
-const eventTypePattern = /^[a-z][a-z0-9.:_-]{0,127}$/;
+const eventTypes = new Set<string>(WORKSTREAM_EVENT_TYPES);
 const workstreamStatuses = new Set([
   "draft",
   "planning",
@@ -69,12 +71,12 @@ export function requireId(value: string, field = "id"): string {
   return trimmed;
 }
 
-export function requireEventType(value: string): string {
+export function requireEventType(value: string): WorkstreamEventType {
   const trimmed = requireString(value, "type", 128);
-  if (!eventTypePattern.test(trimmed)) {
+  if (!eventTypes.has(trimmed)) {
     throw new Error("type must be a valid event type.");
   }
-  return trimmed;
+  return trimmed as WorkstreamEventType;
 }
 
 export function requireWorkstreamStatus(
@@ -138,9 +140,40 @@ export function assertJsonCompatible(value: unknown): void {
     return;
   }
 
-  try {
-    JSON.stringify(value);
-  } catch {
+  if (!isJsonCompatible(value, new Set())) {
     throw new Error("payload must be JSON serializable.");
   }
+}
+
+function isJsonCompatible(value: unknown, seen: Set<object>): boolean {
+  if (value === null) {
+    return true;
+  }
+
+  switch (typeof value) {
+    case "string":
+    case "boolean":
+      return true;
+    case "number":
+      return Number.isFinite(value);
+    case "object":
+      break;
+    default:
+      return false;
+  }
+
+  if (seen.has(value)) {
+    return false;
+  }
+  seen.add(value);
+
+  if (Array.isArray(value)) {
+    return value.every((item) => isJsonCompatible(item, seen));
+  }
+
+  if (Object.getPrototypeOf(value) !== Object.prototype) {
+    return false;
+  }
+
+  return Object.values(value as Record<string, unknown>).every((item) => isJsonCompatible(item, seen));
 }

--- a/packages/orchestrator/test/persistence.test.ts
+++ b/packages/orchestrator/test/persistence.test.ts
@@ -112,7 +112,7 @@ describe("SqliteOrchestratorStore", () => {
     `).run();
     legacy.prepare(`
       INSERT INTO workstream_events (id, workstream_id, sequence, type, message, payload_json, created_at)
-      VALUES ('legacy-event', 'legacy-ws', 1, 'workstream.created', 'Created before migration', '{"ok":true}', '2026-05-01T00:00:01.000Z')
+      VALUES ('legacy-event', 'legacy-ws', 1, 'plan.created', 'Created before migration', '{"ok":true}', '2026-05-01T00:00:01.000Z')
     `).run();
     legacy.prepare(`
       INSERT INTO plans (id, workstream_id, title, body, status, created_at, updated_at)
@@ -135,7 +135,9 @@ describe("SqliteOrchestratorStore", () => {
       summary: "Legacy description",
       status: "running"
     });
-    expect(migrated.listEvents("legacy-ws")).toEqual([expect.objectContaining({ id: "legacy-event" })]);
+    expect(migrated.listEvents("legacy-ws")).toEqual([
+      expect.objectContaining({ id: "legacy-event", type: "plan_created", payload: { ok: true } })
+    ]);
     expect(migrated.listPlans("legacy-ws")).toEqual([expect.objectContaining({ id: "legacy-plan" })]);
     expect(migrated.listAgentRuns("legacy-ws")).toEqual([expect.objectContaining({ id: "legacy-run" })]);
     migrated.close();
@@ -212,7 +214,7 @@ describe("SqliteOrchestratorStore", () => {
     store.close();
   });
 
-  it("appends and reads ordered timeline events with structured payloads", async () => {
+  it("appends every canonical timeline event type and reads them in stable sequence order with structured payloads", async () => {
     const dataDir = await createTempDir();
     const store = createSqliteOrchestratorStore({ dataDir });
     const workstream = store.createWorkstream({
@@ -222,31 +224,165 @@ describe("SqliteOrchestratorStore", () => {
       createdBy: "hermes"
     });
 
-    const first = store.appendEvent({
-      workstreamId: workstream.id,
-      type: "workstream.created",
-      message: "Workstream created",
-      payload: { source: "test" }
-    });
-    const second = store.appendEvent({
-      workstreamId: workstream.id,
-      type: "agent.run.started",
-      message: "Agent run started"
-    });
+    const eventTypes = [
+      "user_message",
+      "coordinator_message",
+      "plan_created",
+      "plan_approved",
+      "agent_started",
+      "agent_completed",
+      "command_ran",
+      "commit_created",
+      "branch_pushed",
+      "pr_opened",
+      "ci_started",
+      "ci_passed",
+      "ci_failed",
+      "review_summary_created",
+      "human_action_required",
+      "workstream_completed"
+    ] as const;
+
+    const created = eventTypes.map((type, index) =>
+      store.appendEvent({
+        workstreamId: workstream.id,
+        type,
+        message: `Timeline event ${index + 1}`,
+        payload:
+          index === 0
+            ? {
+                source: "test",
+                command: ["npm", "test"],
+                exitCode: 0,
+                nested: { ok: true, count: 2 },
+                labels: ["timeline", "audit"],
+                optional: null
+              }
+            : undefined
+      })
+    );
 
     expect(store.listEvents(workstream.id)).toEqual([
       expect.objectContaining({
-        id: first.id,
+        id: created[0].id,
         sequence: 1,
-        payload: { source: "test" }
+        type: "user_message",
+        payload: {
+          source: "test",
+          command: ["npm", "test"],
+          exitCode: 0,
+          nested: { ok: true, count: 2 },
+          labels: ["timeline", "audit"],
+          optional: null
+        }
       }),
-      expect.objectContaining({
-        id: second.id,
-        sequence: 2,
-        payload: null
-      })
+      ...created.slice(1).map((event, index) =>
+        expect.objectContaining({
+          id: event.id,
+          sequence: index + 2,
+          type: eventTypes[index + 1],
+          payload: null
+        })
+      )
     ]);
     store.close();
+  });
+
+  it("rejects non-canonical event types at the service and SQLite boundaries", async () => {
+    const dataDir = await createTempDir();
+    const store = createSqliteOrchestratorStore({ dataDir });
+    const workstream = store.createWorkstream({
+      title: "Event type validation",
+      goal: "Reject non-canonical timeline events.",
+      repo: "ss-andrade/mergepilot",
+      createdBy: "hermes"
+    });
+
+    expect(() =>
+      store.appendEvent({
+        workstreamId: workstream.id,
+        type: "workstream.created" as never,
+        message: "Legacy dotted type"
+      })
+    ).toThrow(/valid event type/i);
+
+    const db = new Database(store.databasePath);
+    expect(() =>
+      db
+        .prepare(
+          `INSERT INTO workstream_events (id, workstream_id, sequence, type, message, payload_json, created_at)
+           VALUES ('bad-event', ?, 1, 'workstream.created', 'Bad event', NULL, '2026-05-01T00:00:00.000Z')`
+        )
+        .run(workstream.id)
+    ).toThrow();
+    db.close();
+    expect(store.listEvents(workstream.id)).toEqual([]);
+    store.close();
+  });
+
+  it("rejects payloads that cannot be faithfully represented as JSON metadata", async () => {
+    const dataDir = await createTempDir();
+    const store = createSqliteOrchestratorStore({ dataDir });
+    const workstream = store.createWorkstream({
+      title: "Metadata validation",
+      goal: "Reject lossy payload metadata.",
+      repo: "ss-andrade/mergepilot",
+      createdBy: "hermes"
+    });
+
+    expect(() =>
+      store.appendEvent({
+        workstreamId: workstream.id,
+        type: "command_ran",
+        message: "Invalid payload",
+        payload: { command: "npm test", elided: undefined }
+      })
+    ).toThrow(/payload/i);
+    expect(() =>
+      store.appendEvent({
+        workstreamId: workstream.id,
+        type: "command_ran",
+        message: "Invalid payload",
+        payload: { command: "npm test", metadata: () => "not JSON" }
+      })
+    ).toThrow(/payload/i);
+    store.close();
+  });
+
+  it("prevents direct mutation or deletion of persisted events", async () => {
+    const dataDir = await createTempDir();
+    const store = createSqliteOrchestratorStore({ dataDir });
+    const workstream = store.createWorkstream({
+      title: "Immutable timeline",
+      goal: "Prevent audit event tampering.",
+      repo: "ss-andrade/mergepilot",
+      createdBy: "hermes"
+    });
+    const event = store.appendEvent({
+      workstreamId: workstream.id,
+      type: "command_ran",
+      message: "npm test",
+      payload: { command: ["npm", "test"], exitCode: 0 }
+    });
+    store.close();
+
+    const db = new Database(path.join(dataDir, "mergepilot.sqlite3"));
+    expect(() =>
+      db.prepare("UPDATE workstream_events SET message = 'tampered' WHERE id = ?").run(event.id)
+    ).toThrow(/immutable/i);
+    expect(() => db.prepare("DELETE FROM workstream_events WHERE id = ?").run(event.id)).toThrow(/immutable/i);
+    db.close();
+
+    const reopened = createSqliteOrchestratorStore({ dataDir });
+    expect(reopened.listEvents(workstream.id)).toEqual([
+      expect.objectContaining({
+        id: event.id,
+        type: "command_ran",
+        message: "npm test",
+        payload: { command: ["npm", "test"], exitCode: 0 }
+      })
+    ]);
+    reopened.close();
   });
 
   it("creates plans and agent runs linked to a workstream", async () => {

--- a/packages/orchestrator/test/service.test.ts
+++ b/packages/orchestrator/test/service.test.ts
@@ -35,7 +35,7 @@ describe("LocalOrchestratorService", () => {
     expect(orchestrator.updateWorkstreamStatus(workstream.id, "planning")).toMatchObject({ status: "planning" });
     orchestrator.appendEvent({
       workstreamId: workstream.id,
-      type: "service.ready",
+      type: "coordinator_message",
       message: "Service ready"
     });
 
@@ -53,7 +53,7 @@ describe("LocalOrchestratorService", () => {
       title: "Service workstream"
     });
     expect(orchestrator.listEvents(workstream.id)).toEqual([
-      expect.objectContaining({ type: "service.ready" })
+      expect.objectContaining({ type: "coordinator_message" })
     ]);
 
     await orchestrator.stop();

--- a/tests/runtime/electron.spec.ts
+++ b/tests/runtime/electron.spec.ts
@@ -49,18 +49,18 @@ test("built Electron app persists workstreams across restarts in an isolated use
 
     await firstRun.page.getByRole("button", { name: "New Workstream" }).click();
     await expect(firstRun.page.getByText("1 persisted workstream(s)")).toBeVisible();
-    await expect(firstRun.page.getByText("workstream.created")).toBeVisible();
+    await expect(firstRun.page.getByText("user_message")).toBeVisible();
 
     await firstRun.page.getByRole("button", { name: "Add event" }).click();
-    await expect(firstRun.page.getByText("timeline.note")).toBeVisible();
+    await expect(firstRun.page.getByText("coordinator_message")).toBeVisible();
     await firstRun.electronApp.close();
 
     const secondRun = await launchApp();
     await secondRun.page.getByRole("button", { name: "Start" }).click();
     await expect(secondRun.page.getByText("1 persisted workstream(s)")).toBeVisible();
     await expect(secondRun.page.getByRole("heading", { name: "Workstream 1" })).toBeVisible();
-    await expect(secondRun.page.getByText("workstream.created")).toBeVisible();
-    await expect(secondRun.page.getByText("timeline.note")).toBeVisible();
+    await expect(secondRun.page.getByText("user_message")).toBeVisible();
+    await expect(secondRun.page.getByText("coordinator_message")).toBeVisible();
     await secondRun.electronApp.close();
 
     expect(runtimeFailures).toEqual([]);

--- a/tests/runtime/renderer.spec.ts
+++ b/tests/runtime/renderer.spec.ts
@@ -60,7 +60,16 @@ test("web renderer runs against a mocked mergePilot bridge", async ({ page }) =>
           return created;
         },
         list: async () => [...workstreams],
-        get: async (id) => workstreams.find((workstream) => workstream.id === id) ?? null
+        get: async (id) => workstreams.find((workstream) => workstream.id === id) ?? null,
+        updateStatus: async (id, nextStatus) => {
+          const workstream = workstreams.find((item) => item.id === id);
+          if (!workstream) {
+            throw new Error(`Missing workstream ${id}`);
+          }
+          workstream.status = nextStatus;
+          workstream.updatedAt = now;
+          return workstream;
+        }
       },
       events: {
         append: async (input) => {
@@ -95,6 +104,6 @@ test("web renderer runs against a mocked mergePilot bridge", async ({ page }) =>
   await page.getByRole("button", { name: "Create workstream" }).click();
 
   await expect(page.getByRole("heading", { level: 2, name: "Workstream 1" })).toBeVisible();
-  await expect(page.getByText("workstream.created")).toBeVisible();
+  await expect(page.getByText("user_message")).toBeVisible();
   expect(runtimeFailures).toEqual([]);
 });


### PR DESCRIPTION
## Summary
- Adds a canonical `WorkstreamEventType` timeline enum for issue #4 event names and uses it across orchestrator, IPC, preload, and renderer types.
- Adds runtime and SQLite validation for timeline event types, structured JSON metadata, and stable per-workstream sequence ordering.
- Makes persisted events immutable with SQLite triggers and adds migration handling for legacy dotted event types.
- Updates renderer/runtime tests to use canonical timeline events.

## Verification
- `npm run test -w @mergepilot/orchestrator -- --run test/persistence.test.ts test/service.test.ts`
- `npm run typecheck`
- `npm run test`
- `npm run build -w @mergepilot/web`
- `npm run test:e2e:web`
- `npm run verify`
- `npm run test:e2e:electron` (exited 0; Electron runtime test skipped by Linux display preflight, native module ABI rebuilt back to Node afterward)
- Independent review completed; stale Electron E2E assertions were fixed before PR.
- Secret/dangerous API diff scan: 0 matches.

Closes #4
