### PR TITLE
feat(web): build basic workstream UI

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -99,6 +99,14 @@ function getStatusTone(status: Workstream["status"]) {
   return "muted";
 }
 
+function deriveTitleFromGoal(goal: string) {
+  const normalized = goal.trim().replace(/\s+/g, " ");
+  if (!normalized) return "";
+  const sentence = normalized.split(/[.!?]/)[0]?.trim() || normalized;
+  const concise = sentence.split(/\s+(?:with|for|to|so that)\s+/i)[0]?.trim() || sentence;
+  return concise.length > 32 ? `${concise.slice(0, 29).trim()}...` : concise;
+}
+
 function Kbd({ children }: { children: ReactNode }) {
   return <kbd className="mp-kbd">{children}</kbd>;
 }
@@ -243,6 +251,18 @@ export function App() {
     void createWorkstream(formState);
   }
 
+  function updateGoalPrompt(goal: string) {
+    setFormState((current) => {
+      const previousDerived = deriveTitleFromGoal(current.goal);
+      const shouldDeriveTitle = !current.title.trim() || current.title === previousDerived;
+      return {
+        ...current,
+        goal,
+        title: shouldDeriveTitle ? deriveTitleFromGoal(goal) : current.title
+      };
+    });
+  }
+
   const commandActions = useMemo(
     () => [
       {
@@ -350,7 +370,7 @@ export function App() {
             </Button>
             <div>
               <p className="mp-eyebrow">Local-first workspace</p>
-              <h2>{selectedWorkstream?.title ?? "MergePilot app shell"}</h2>
+              <h2>{selectedWorkstream?.title ?? "Workstream workspace"}</h2>
             </div>
           </div>
           <div className="mp-topbar__actions">
@@ -367,14 +387,14 @@ export function App() {
                 <PlusIcon aria-hidden="true" />
                 New Workstream
               </DialogTrigger>
-              <NewWorkstreamDialog formState={formState} setFormState={setFormState} onSubmit={submitWorkstream} />
+              <NewWorkstreamDialog formState={formState} setFormState={setFormState} onGoalChange={updateGoalPrompt} onSubmit={submitWorkstream} />
             </Dialog>
           </div>
         </header>
 
         {error ? <p className="mp-error" role="alert">{error}</p> : null}
 
-        <section className="mp-hero" aria-label="Current workstream summary">
+        <section className="mp-hero" aria-label="Current workstream overview">
           <div className="mp-hero__copy">
             <Badge tone={isRunning ? "success" : "warning"}>
               <span className={`mp-status-dot${isRunning ? "" : " is-idle"}`} aria-hidden="true" />
@@ -405,7 +425,7 @@ export function App() {
                 Refresh
               </Button>
             </div>
-            <div className="mp-card-grid">
+            <div className="mp-card-grid" role="region" aria-label="Workstream list">
               {workstreams.length > 0
                 ? workstreams.map((workstream) => (
                     <Card className="mp-workstream-card" key={workstream.id}>
@@ -417,10 +437,10 @@ export function App() {
                       <p>{workstream.summary ?? workstream.goal}</p>
                       <code>{workstream.repo}</code>
                       <div className="mp-card__footer">
-                        <Button variant="outline" onClick={() => void selectWorkstream(workstream.id)}>
+                        <Button aria-label={`View timeline for ${workstream.title}`} variant="outline" onClick={() => void selectWorkstream(workstream.id)}>
                           View timeline
                         </Button>
-                        <Button variant="ghost" onClick={() => void appendTimelineEvent(workstream.id)}>
+                        <Button aria-label={`Add event to ${workstream.title}`} variant="ghost" onClick={() => void appendTimelineEvent(workstream.id)}>
                           Add event
                         </Button>
                       </div>
@@ -435,6 +455,57 @@ export function App() {
                     </Card>
                   ))}
             </div>
+
+            <Panel className="mp-workstream-detail" role="region" aria-label="Workstream detail">
+              {selectedWorkstream ? (
+                <>
+                  <div className="mp-section-heading">
+                    <div>
+                      <p className="mp-eyebrow">Workstream detail page</p>
+                      <h3>{selectedWorkstream.title}</h3>
+                    </div>
+                    <Badge tone={getStatusTone(selectedWorkstream.status)}>{selectedWorkstream.status}</Badge>
+                  </div>
+                  <p className="mp-detail-summary">{selectedWorkstream.summary ?? selectedWorkstream.goal}</p>
+                  <dl className="mp-detail-grid">
+                    <div>
+                      <dt>Status</dt>
+                      <dd>{selectedWorkstream.status}</dd>
+                    </div>
+                    <div>
+                      <dt>Repository</dt>
+                      <dd>{selectedWorkstream.repo}</dd>
+                    </div>
+                    <div>
+                      <dt>Created by</dt>
+                      <dd>{selectedWorkstream.createdBy}</dd>
+                    </div>
+                    <div>
+                      <dt>Updated</dt>
+                      <dd>{formatDate(selectedWorkstream.updatedAt)}</dd>
+                    </div>
+                  </dl>
+                  <div className="mp-detail-goal">
+                    <span>Goal prompt</span>
+                    <p>{selectedWorkstream.goal}</p>
+                  </div>
+                  <div className="mp-card__footer">
+                    <Button variant="outline" onClick={() => void appendTimelineEvent(selectedWorkstream.id)}>
+                      Add event
+                    </Button>
+                    <Button variant="ghost" onClick={() => void refreshOrchestrator(selectedWorkstream.id)}>
+                      Refresh detail
+                    </Button>
+                  </div>
+                </>
+              ) : (
+                <div className="mp-empty-state">
+                  <WorkflowIcon aria-hidden="true" />
+                  <strong>Select a workstream</strong>
+                  <p>Create or select a workstream to inspect status, summary, goal, and repository context.</p>
+                </div>
+              )}
+            </Panel>
 
             <Panel className="mp-timeline" id="timeline" aria-label="Event timeline">
               <div className="mp-section-heading">
@@ -464,8 +535,8 @@ export function App() {
                 ) : (
                   <div className="mp-empty-state">
                     <CheckCircle2Icon aria-hidden="true" />
-                    <strong>Awaiting persisted events</strong>
-                    <p>Create a workstream to append and read local timeline data.</p>
+                    <strong>No events yet</strong>
+                    <p>This workstream timeline is ready for coordinator messages, plan updates, commands, and PR evidence.</p>
                   </div>
                 )}
               </div>
@@ -473,6 +544,19 @@ export function App() {
           </section>
 
           <aside className="mp-side-column" id="agents">
+            <Panel className="mp-human-attention" role="region" aria-label="Human attention">
+              <p className="mp-eyebrow">Human attention</p>
+              <h3>Plan approvals, blockers, and access requests</h3>
+              <p>
+                MergePilot will surface decisions that need a human before agents continue: plan approval,
+                credentials/access requests, failed checks, and merge readiness.
+              </p>
+              <div className="mp-attention-placeholder">
+                <BellIcon aria-hidden="true" />
+                <span>No human action required right now.</span>
+              </div>
+            </Panel>
+
             <Panel className="mp-inspector">
               <p className="mp-eyebrow">Agent readiness</p>
               <h3>Operational lanes</h3>
@@ -545,10 +629,12 @@ function StatusLine({ icon, label, value }: { icon: ReactNode; label: string; va
 
 function NewWorkstreamDialog({
   formState,
+  onGoalChange,
   onSubmit,
   setFormState
 }: {
   formState: WorkstreamFormState;
+  onGoalChange: (goal: string) => void;
   onSubmit: (event: FormEvent<HTMLFormElement>) => void;
   setFormState: (state: WorkstreamFormState) => void;
 }) {
@@ -561,23 +647,23 @@ function NewWorkstreamDialog({
         </DialogHeader>
         <DialogBody className="mp-form-grid">
           <div>
+            <Label htmlFor="workstream-goal">Goal prompt</Label>
+            <Textarea
+              id="workstream-goal"
+              onChange={(event) => onGoalChange(event.target.value)}
+              placeholder="What should agents coordinate, verify, and report?"
+              required
+              rows={4}
+              value={formState.goal}
+            />
+          </div>
+          <div>
             <Label htmlFor="workstream-title">Title</Label>
             <Input
               id="workstream-title"
               onChange={(event) => setFormState({ ...formState, title: event.target.value })}
-              placeholder="Ship queued review fixes"
-              required
+              placeholder="Derived from the goal, editable before creation"
               value={formState.title}
-            />
-          </div>
-          <div>
-            <Label htmlFor="workstream-goal">Goal</Label>
-            <Textarea
-              id="workstream-goal"
-              onChange={(event) => setFormState({ ...formState, goal: event.target.value })}
-              placeholder="What should agents coordinate, verify, and report?"
-              rows={4}
-              value={formState.goal}
             />
           </div>
           <div>

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -624,6 +624,57 @@ kbd {
   padding: 16px;
 }
 
+.mp-workstream-detail,
+.mp-human-attention {
+  display: grid;
+  gap: 14px;
+}
+
+.mp-detail-summary,
+.mp-human-attention > p:not(.mp-eyebrow),
+.mp-detail-goal p {
+  margin: 0;
+  color: var(--muted-foreground);
+}
+
+.mp-detail-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 8px;
+  margin: 0;
+}
+
+.mp-detail-grid div,
+.mp-detail-goal,
+.mp-attention-placeholder {
+  padding: 10px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  background: var(--panel-strong);
+}
+
+.mp-detail-grid dt,
+.mp-detail-goal span {
+  color: var(--muted-foreground);
+  font-size: 0.72rem;
+  font-weight: 760;
+  text-transform: uppercase;
+}
+
+.mp-detail-grid dd {
+  margin: 3px 0 0;
+  overflow-wrap: anywhere;
+  font-weight: 700;
+}
+
+.mp-attention-placeholder {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  color: var(--warning);
+  background: var(--warning-bg);
+}
+
 .mp-timeline__list {
   display: grid;
   overflow: hidden;
@@ -1143,7 +1194,8 @@ kbd {
   }
 
   .mp-card-grid,
-  .mp-side-column {
+  .mp-side-column,
+  .mp-detail-grid {
     grid-template-columns: 1fr;
   }
 }

--- a/tests/runtime/renderer.spec.ts
+++ b/tests/runtime/renderer.spec.ts
@@ -13,8 +13,52 @@ test("web renderer runs against a mocked mergePilot bridge", async ({ page }) =>
     const now = new Date("2026-05-02T00:00:00.000Z").toISOString();
     let running = false;
     let sequence = 0;
-    const workstreams: Workstream[] = [];
-    const events: WorkstreamEvent[] = [];
+    const createCalls: CreateWorkstreamInput[] = [];
+    const workstreams: Workstream[] = [
+      {
+        id: "ws-empty",
+        title: "Review dependency update",
+        goal: "Review and merge the dependency update after checks pass.",
+        repo: "ss-andrade/mergepilot",
+        createdBy: "renderer",
+        summary: "Dependency update is waiting for a review pass.",
+        status: "awaiting_review",
+        createdAt: now,
+        updatedAt: now
+      }
+    ];
+    const events: WorkstreamEvent[] = [
+      {
+        id: "event-existing-1",
+        workstreamId: "ws-seeded",
+        sequence: 1,
+        type: "plan_created",
+        message: "Initial implementation plan was drafted.",
+        payload: { source: "mock" },
+        createdAt: now
+      },
+      {
+        id: "event-existing-2",
+        workstreamId: "ws-seeded",
+        sequence: 2,
+        type: "human_action_required",
+        message: "Plan approval is needed before agents continue.",
+        payload: { reason: "plan_approval" },
+        createdAt: now
+      }
+    ];
+    workstreams.unshift({
+      id: "ws-seeded",
+      title: "Implement persisted timeline",
+      goal: "Show canonical events for an existing workstream.",
+      repo: "ss-andrade/mergepilot",
+      createdBy: "renderer",
+      summary: "Timeline events are ready for inspection.",
+      status: "awaiting_plan_approval",
+      createdAt: now,
+      updatedAt: now
+    });
+    (window as typeof window & { __mergePilotCreateCalls: CreateWorkstreamInput[] }).__mergePilotCreateCalls = createCalls;
     const status = (): OrchestratorStatus => ({
       state: running ? "running" : "stopped",
       dataDir: "/tmp/mergepilot-renderer-mock/orchestrator",
@@ -45,6 +89,7 @@ test("web renderer runs against a mocked mergePilot bridge", async ({ page }) =>
       },
       workstreams: {
         create: async (input) => {
+          createCalls.push(input);
           const created: Workstream = {
             id: `ws-${workstreams.length + 1}`,
             title: input.title,
@@ -93,17 +138,42 @@ test("web renderer runs against a mocked mergePilot bridge", async ({ page }) =>
 
   await page.goto("/");
 
-  await expect(page.getByRole("heading", { name: "MergePilot app shell" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Workstreams", exact: true })).toBeVisible();
   await expect(page.getByText("Electron mocked")).toBeVisible();
   await expect(page.getByText("stopped", { exact: true })).toBeVisible();
 
+  await page.getByRole("button", { name: "Start" }).click();
+  await expect(page.getByRole("region", { name: "Workstream list" })).toContainText("Implement persisted timeline");
+  await expect(page.getByRole("region", { name: "Workstream detail" })).toContainText("Status");
+  await expect(page.getByRole("region", { name: "Workstream detail" })).toContainText("awaiting_plan_approval");
+  await expect(page.getByRole("region", { name: "Workstream detail" })).toContainText("Timeline events are ready for inspection.");
+  await expect(page.getByRole("region", { name: "Workstream detail" })).toContainText("Show canonical events for an existing workstream.");
+  await expect(page.getByRole("region", { name: "Workstream detail" })).toContainText("ss-andrade/mergepilot");
+  await expect(page.getByRole("region", { name: "Workstream detail" })).toContainText("renderer");
+  await expect(page.getByRole("region", { name: "Event timeline" })).toContainText("plan_created");
+  await expect(page.getByRole("region", { name: "Event timeline" })).toContainText("human_action_required");
+  await expect(page.getByRole("region", { name: "Human attention" })).toContainText("Plan approvals, blockers, and access requests");
+
+  await page.getByRole("button", { name: /^Review dependency update awaiting_review$/ }).click();
+  await expect(page.getByRole("region", { name: "Workstream detail" })).toContainText("Review and merge the dependency update after checks pass.");
+  await expect(page.getByRole("region", { name: "Event timeline" })).toContainText("No events yet");
+
   await page.getByRole("button", { name: "New Workstream" }).click();
-  await page.getByLabel("Title").fill("Workstream 1");
-  await page.getByLabel("Goal").fill("Created through the secure Electron bridge.");
+  await page.getByLabel("Goal prompt").fill("Build a basic workstream UI with a list, detail page, and human attention placeholder.");
+  await expect(page.getByLabel("Title")).toHaveValue("Build a basic workstream UI");
+  await page.getByLabel("Summary").fill("Basic workstream UI is ready to track.");
   await page.getByLabel("Repository").fill("ss-andrade/mergepilot");
   await page.getByRole("button", { name: "Create workstream" }).click();
 
-  await expect(page.getByRole("heading", { level: 2, name: "Workstream 1" })).toBeVisible();
+  await expect(page.getByRole("heading", { level: 2, name: "Build a basic workstream UI" })).toBeVisible();
+  await expect(page.getByRole("region", { name: "Workstream list" })).toContainText("Basic workstream UI is ready to track.");
   await expect(page.getByText("user_message")).toBeVisible();
+  await expect.poll(() => page.evaluate(() => (window as typeof window & { __mergePilotCreateCalls: CreateWorkstreamInput[] }).__mergePilotCreateCalls.at(-1))).toMatchObject({
+    title: "Build a basic workstream UI",
+    goal: "Build a basic workstream UI with a list, detail page, and human attention placeholder.",
+    repo: "ss-andrade/mergepilot",
+    createdBy: "renderer",
+    summary: "Basic workstream UI is ready to track."
+  });
   expect(runtimeFailures).toEqual([]);
 });


### PR DESCRIPTION
## Summary
- Builds the first goal-first workstream product UI with a workstream list, editable derived title, and canonical create payload.
- Adds a selected workstream detail surface showing status, summary, goal, repo, creator, updated timestamp, and actions.
- Adds event timeline empty/list states and a human-attention placeholder for plan approvals, blockers, access requests, checks, and merge readiness.
- Expands renderer runtime coverage for seeded workstreams, detail navigation, timeline placeholders, and create payloads.

Closes #3

## Verification
- `npm run typecheck`
- `npm run test`
- `npm run build -w @mergepilot/web`
- `npm run test:e2e:web`
- `npm run verify`
- `npm run test:e2e:electron` (Linux display preflight skipped runtime test; native module rebuilt back to Node)
- `git diff --check`
- Diff hygiene scan for secret-like strings and dangerous APIs

## Review
- Independent review completed; goal-first form ordering/required-state and button accessibility follow-ups were fixed before PR.