### PR TITLE
feat: add GitHub repository connection

### DIFF
--- a/apps/desktop/src/main/orchestrator-ipc.test.ts
+++ b/apps/desktop/src/main/orchestrator-ipc.test.ts
@@ -69,7 +69,39 @@ describe("orchestrator IPC handlers", () => {
         payload: { ok: true },
         createdAt: "2026-05-01T00:02:00.000Z"
       })),
-      listEvents: vi.fn(() => [])
+      listEvents: vi.fn(() => []),
+      connectGitHubRepository: vi.fn(() => ({
+        id: "repo-1",
+        owner: "ss-andrade",
+        name: "mergepilot",
+        defaultBranch: "main",
+        htmlUrl: "https://github.com/ss-andrade/mergepilot",
+        apiUrl: "https://api.github.com/repos/ss-andrade/mergepilot",
+        connectedAt: "2026-05-01T00:03:00.000Z",
+        updatedAt: "2026-05-01T00:03:00.000Z",
+        selectedAt: null
+      })),
+      listGitHubRepositories: vi.fn(() => []),
+      selectGitHubRepository: vi.fn(() => ({
+        id: "repo-1",
+        owner: "ss-andrade",
+        name: "mergepilot",
+        defaultBranch: "main",
+        htmlUrl: null,
+        apiUrl: null,
+        connectedAt: "2026-05-01T00:03:00.000Z",
+        updatedAt: "2026-05-01T00:04:00.000Z",
+        selectedAt: "2026-05-01T00:04:00.000Z"
+      })),
+      recordGitHubRepositoryConnectionError: vi.fn(() => ({
+        id: "evt-2",
+        workstreamId: "ws-1",
+        sequence: 2,
+        type: "human_action_required",
+        message: "GitHub repository access needs attention.",
+        payload: { integration: "github" },
+        createdAt: "2026-05-01T00:05:00.000Z"
+      }))
     };
 
     registerOrchestratorIpcHandlers(ipc, orchestrator);
@@ -93,6 +125,27 @@ describe("orchestrator IPC handlers", () => {
       id: "ws-1",
       status: "planning"
     });
+    await expect(
+      ipc.invoke("github:repositories:connect", {
+        owner: "ss-andrade",
+        name: "mergepilot",
+        defaultBranch: "main",
+        htmlUrl: "https://github.com/ss-andrade/mergepilot",
+        apiUrl: "https://api.github.com/repos/ss-andrade/mergepilot"
+      })
+    ).resolves.toMatchObject({ id: "repo-1" });
+    await expect(ipc.invoke("github:repositories:select", { repositoryId: "repo-1" })).resolves.toMatchObject({
+      id: "repo-1",
+      selectedAt: expect.any(String)
+    });
+    await expect(
+      ipc.invoke("github:repositories:report-error", {
+        workstreamId: "ws-1",
+        repository: "ss-andrade/mergepilot",
+        message: "GitHub repository access needs attention.",
+        reason: "not_found"
+      })
+    ).resolves.toMatchObject({ type: "human_action_required" });
 
     expect(orchestrator.createWorkstream).toHaveBeenCalledWith({
       title: "IPC work",
@@ -107,6 +160,20 @@ describe("orchestrator IPC handlers", () => {
       payload: { ok: true }
     });
     expect(orchestrator.updateWorkstreamStatus).toHaveBeenCalledWith("ws-1", "planning");
+    expect(orchestrator.connectGitHubRepository).toHaveBeenCalledWith({
+      owner: "ss-andrade",
+      name: "mergepilot",
+      defaultBranch: "main",
+      htmlUrl: "https://github.com/ss-andrade/mergepilot",
+      apiUrl: "https://api.github.com/repos/ss-andrade/mergepilot"
+    });
+    expect(orchestrator.selectGitHubRepository).toHaveBeenCalledWith("repo-1");
+    expect(orchestrator.recordGitHubRepositoryConnectionError).toHaveBeenCalledWith({
+      workstreamId: "ws-1",
+      repository: "ss-andrade/mergepilot",
+      message: "GitHub repository access needs attention.",
+      reason: "not_found"
+    });
   });
 
   it("validates IPC input before calling services", async () => {
@@ -120,7 +187,11 @@ describe("orchestrator IPC handlers", () => {
       getWorkstream: vi.fn(),
       updateWorkstreamStatus: vi.fn(),
       appendEvent: vi.fn(),
-      listEvents: vi.fn()
+      listEvents: vi.fn(),
+      connectGitHubRepository: vi.fn(),
+      listGitHubRepositories: vi.fn(),
+      selectGitHubRepository: vi.fn(),
+      recordGitHubRepositoryConnectionError: vi.fn()
     };
 
     registerOrchestratorIpcHandlers(ipc, orchestrator);
@@ -144,9 +215,15 @@ describe("orchestrator IPC handlers", () => {
       })
     ).rejects.toThrow(/payload/i);
     await expect(ipc.invoke("events:list", { workstreamId: "../bad" })).rejects.toThrow(/workstreamId/i);
+    await expect(
+      ipc.invoke("github:repositories:connect", { owner: "bad owner", name: "mergepilot", defaultBranch: "main" })
+    ).rejects.toThrow(/owner/i);
+    await expect(ipc.invoke("github:repositories:select", { repositoryId: "../bad" })).rejects.toThrow(/repositoryId/i);
     expect(orchestrator.createWorkstream).not.toHaveBeenCalled();
     expect(orchestrator.updateWorkstreamStatus).not.toHaveBeenCalled();
     expect(orchestrator.appendEvent).not.toHaveBeenCalled();
     expect(orchestrator.listEvents).not.toHaveBeenCalled();
+    expect(orchestrator.connectGitHubRepository).not.toHaveBeenCalled();
+    expect(orchestrator.selectGitHubRepository).not.toHaveBeenCalled();
   });
 });

--- a/apps/desktop/src/main/orchestrator-ipc.ts
+++ b/apps/desktop/src/main/orchestrator-ipc.ts
@@ -1,7 +1,10 @@
 import type {
   AppendWorkstreamEventInput,
+  ConnectGitHubRepositoryInput,
   CreateWorkstreamInput,
   LocalOrchestratorService,
+  ReportGitHubRepositoryConnectionErrorInput,
+  WorkstreamGitHubRepositoryScope,
   WorkstreamEventType,
   WorkstreamStatus
 } from "@mergepilot/orchestrator";
@@ -28,6 +31,10 @@ export function registerOrchestratorIpcHandlers(
     | "listWorkstreams"
     | "getWorkstream"
     | "updateWorkstreamStatus"
+    | "connectGitHubRepository"
+    | "listGitHubRepositories"
+    | "selectGitHubRepository"
+    | "recordGitHubRepositoryConnectionError"
     | "appendEvent"
     | "listEvents"
   >
@@ -61,6 +68,20 @@ export function registerOrchestratorIpcHandlers(
     return orchestrator.updateWorkstreamStatus(id, parseWorkstreamStatus(input.status));
   });
 
+  ipc.handle("github:repositories:connect", (_event, rawInput) => {
+    return orchestrator.connectGitHubRepository(parseConnectGitHubRepositoryInput(rawInput));
+  });
+
+  ipc.handle("github:repositories:list", () => orchestrator.listGitHubRepositories());
+
+  ipc.handle("github:repositories:select", (_event, rawInput) => {
+    return orchestrator.selectGitHubRepository(parseIdInput(rawInput, "repositoryId"));
+  });
+
+  ipc.handle("github:repositories:report-error", (_event, rawInput) => {
+    return orchestrator.recordGitHubRepositoryConnectionError(parseReportGitHubRepositoryConnectionErrorInput(rawInput));
+  });
+
   ipc.handle("events:append", (_event, rawInput) => {
     return orchestrator.appendEvent(parseAppendEventInput(rawInput));
   });
@@ -83,8 +104,58 @@ function parseCreateWorkstreamInput(rawInput: unknown): CreateWorkstreamInput {
   if ("summary" in input) {
     parsed.summary = optionalBoundedString(input.summary, "summary", 5000);
   }
+  if ("githubRepository" in input && input.githubRepository !== null && input.githubRepository !== undefined) {
+    parsed.githubRepository = parseGitHubRepositoryScope(input.githubRepository);
+  }
 
   return parsed;
+}
+
+function parseConnectGitHubRepositoryInput(rawInput: unknown): ConnectGitHubRepositoryInput {
+  const input = requireRecord(rawInput);
+  const parsed: ConnectGitHubRepositoryInput = {
+    owner: requireGitHubOwner(input.owner),
+    name: requireGitHubRepositoryName(input.name),
+    defaultBranch: requireGitHubDefaultBranch(input.defaultBranch)
+  };
+  if ("htmlUrl" in input) {
+    parsed.htmlUrl = optionalBoundedString(input.htmlUrl, "htmlUrl", 2048);
+  }
+  if ("apiUrl" in input) {
+    parsed.apiUrl = optionalBoundedString(input.apiUrl, "apiUrl", 2048);
+  }
+  return parsed;
+}
+
+function parseGitHubRepositoryScope(rawInput: unknown): WorkstreamGitHubRepositoryScope {
+  const input = requireRecord(rawInput);
+  const parsed: WorkstreamGitHubRepositoryScope = {
+    owner: requireGitHubOwner(input.owner),
+    name: requireGitHubRepositoryName(input.name),
+    defaultBranch: requireGitHubDefaultBranch(input.defaultBranch)
+  };
+  if ("id" in input && input.id !== undefined && input.id !== null) {
+    parsed.id = parseIdInput(input.id, "repositoryId");
+  }
+  if ("htmlUrl" in input) {
+    parsed.htmlUrl = optionalBoundedString(input.htmlUrl, "htmlUrl", 2048);
+  }
+  if ("apiUrl" in input) {
+    parsed.apiUrl = optionalBoundedString(input.apiUrl, "apiUrl", 2048);
+  }
+  return parsed;
+}
+
+function parseReportGitHubRepositoryConnectionErrorInput(
+  rawInput: unknown
+): ReportGitHubRepositoryConnectionErrorInput {
+  const input = requireRecord(rawInput);
+  return {
+    workstreamId: parseIdInput(input.workstreamId, "workstreamId"),
+    repository: requireBoundedString(input.repository, "repository", 2048),
+    message: requireBoundedString(input.message, "message", 2000),
+    reason: requireBoundedString(input.reason, "reason", 160)
+  };
 }
 
 function parseAppendEventInput(rawInput: unknown): AppendWorkstreamEventInput {
@@ -133,6 +204,30 @@ function requireBoundedString(value: unknown, field: string, maxLength: number):
     throw new Error(`${field} must be ${maxLength} characters or fewer.`);
   }
   return trimmed;
+}
+
+function requireGitHubOwner(value: unknown): string {
+  const owner = requireBoundedString(value, "owner", 39);
+  if (!/^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$/.test(owner)) {
+    throw new Error("owner must be a valid GitHub owner.");
+  }
+  return owner;
+}
+
+function requireGitHubRepositoryName(value: unknown): string {
+  const name = requireBoundedString(value, "name", 100);
+  if (!/^[A-Za-z0-9._-]{1,100}$/.test(name) || name === "." || name === ".." || name.toLowerCase() === ".git") {
+    throw new Error("name must be a valid GitHub repository name.");
+  }
+  return name;
+}
+
+function requireGitHubDefaultBranch(value: unknown): string {
+  const branch = requireBoundedString(value, "defaultBranch", 250);
+  if (!/^[A-Za-z0-9][A-Za-z0-9._/-]{0,249}$/.test(branch) || branch.includes("..") || branch.endsWith("/") || branch.endsWith(".")) {
+    throw new Error("defaultBranch must be a valid Git branch name.");
+  }
+  return branch;
 }
 
 function optionalBoundedString(value: unknown, field: string, maxLength: number): string | null {

--- a/apps/desktop/src/preload/preload.cts
+++ b/apps/desktop/src/preload/preload.cts
@@ -48,6 +48,7 @@ export interface Workstream {
   goal: string;
   status: WorkstreamStatus;
   repo: string;
+  githubRepository: WorkstreamGitHubRepositoryScope | null;
   createdBy: string;
   summary: string | null;
   createdAt: string;
@@ -58,8 +59,45 @@ export interface CreateWorkstreamInput {
   title: string;
   goal: string;
   repo: string;
+  githubRepository?: WorkstreamGitHubRepositoryScope | null;
   createdBy: string;
   summary?: string | null;
+}
+
+export interface GitHubRepositoryConnection {
+  id: string;
+  owner: string;
+  name: string;
+  defaultBranch: string;
+  htmlUrl: string | null;
+  apiUrl: string | null;
+  connectedAt: string;
+  updatedAt: string;
+  selectedAt: string | null;
+}
+
+export interface WorkstreamGitHubRepositoryScope {
+  id?: string;
+  owner: string;
+  name: string;
+  defaultBranch: string;
+  htmlUrl?: string | null;
+  apiUrl?: string | null;
+}
+
+export interface ConnectGitHubRepositoryInput {
+  owner: string;
+  name: string;
+  defaultBranch: string;
+  htmlUrl?: string | null;
+  apiUrl?: string | null;
+}
+
+export interface ReportGitHubRepositoryConnectionErrorInput {
+  workstreamId: string;
+  repository: string;
+  message: string;
+  reason: string;
 }
 
 export interface WorkstreamEvent {
@@ -96,6 +134,14 @@ export interface MergePilotDesktopApi {
     get(id: string): Promise<Workstream | null>;
     updateStatus(id: string, status: WorkstreamStatus): Promise<Workstream>;
   };
+  github: {
+    repositories: {
+      connect(input: ConnectGitHubRepositoryInput): Promise<GitHubRepositoryConnection>;
+      list(): Promise<GitHubRepositoryConnection[]>;
+      select(id: string): Promise<GitHubRepositoryConnection>;
+      reportError(input: ReportGitHubRepositoryConnectionErrorInput): Promise<WorkstreamEvent>;
+    };
+  };
   events: {
     append(input: AppendWorkstreamEventInput): Promise<WorkstreamEvent>;
     list(workstreamId: string): Promise<WorkstreamEvent[]>;
@@ -118,6 +164,14 @@ const desktopApi: MergePilotDesktopApi = {
     list: () => ipcRenderer.invoke("workstreams:list"),
     get: (id) => ipcRenderer.invoke("workstreams:get", { workstreamId: id }),
     updateStatus: (id, status) => ipcRenderer.invoke("workstreams:update-status", { workstreamId: id, status })
+  },
+  github: {
+    repositories: {
+      connect: (input) => ipcRenderer.invoke("github:repositories:connect", input),
+      list: () => ipcRenderer.invoke("github:repositories:list"),
+      select: (id) => ipcRenderer.invoke("github:repositories:select", { repositoryId: id }),
+      reportError: (input) => ipcRenderer.invoke("github:repositories:report-error", input)
+    }
   },
   events: {
     append: (input) => ipcRenderer.invoke("events:append", input),

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -34,7 +34,7 @@ import {
   DialogTitle,
   DialogTrigger
 } from "./components/ui/dialog";
-import { Input, Label, Textarea } from "./components/ui/form";
+import { Input, Label, Select, Textarea } from "./components/ui/form";
 import { ThemePreference, useTheme } from "./hooks/useTheme";
 
 interface TimelineState {
@@ -46,7 +46,14 @@ interface WorkstreamFormState {
   title: string;
   goal: string;
   repo: string;
+  repositoryId: string;
   summary: string;
+}
+
+interface GitHubRepositoryFormState {
+  owner: string;
+  name: string;
+  defaultBranch: string;
 }
 
 const fallbackSections = [
@@ -81,7 +88,14 @@ const emptyForm: WorkstreamFormState = {
   title: "",
   goal: "",
   repo: "",
+  repositoryId: "",
   summary: ""
+};
+
+const emptyRepositoryForm: GitHubRepositoryFormState = {
+  owner: "",
+  name: "",
+  defaultBranch: "main"
 };
 
 function formatDate(value: string) {
@@ -116,17 +130,23 @@ export function App() {
   const [runtimeInfo, setRuntimeInfo] = useState<MergePilotRuntimeInfo | null>(null);
   const [orchestratorStatus, setOrchestratorStatus] = useState<OrchestratorStatus | null>(null);
   const [workstreams, setWorkstreams] = useState<Workstream[]>([]);
+  const [repositories, setRepositories] = useState<GitHubRepositoryConnection[]>([]);
   const [timeline, setTimeline] = useState<TimelineState>({ selectedWorkstreamId: null, events: [] });
   const [error, setError] = useState<string | null>(null);
+  const [humanAttentionMessage, setHumanAttentionMessage] = useState<string | null>(null);
+  const [repositoryError, setRepositoryError] = useState<string | null>(null);
   const [commandOpen, setCommandOpen] = useState(false);
   const [newWorkstreamOpen, setNewWorkstreamOpen] = useState(false);
+  const [repositoryDialogOpen, setRepositoryDialogOpen] = useState(false);
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const [commandQuery, setCommandQuery] = useState("");
   const [formState, setFormState] = useState<WorkstreamFormState>(emptyForm);
+  const [repositoryFormState, setRepositoryFormState] = useState<GitHubRepositoryFormState>(emptyRepositoryForm);
 
   const isRunning = orchestratorStatus?.state === "running";
   const selectedWorkstream = workstreams.find((workstream) => workstream.id === timeline.selectedWorkstreamId) ?? null;
+  const selectedRepository = repositories.find((repository) => repository.id === formState.repositoryId) ?? null;
 
   useEffect(() => {
     window.mergePilot.getRuntimeInfo().then(setRuntimeInfo).catch(() => {
@@ -155,12 +175,17 @@ export function App() {
 
     if (status.state !== "running") {
       setWorkstreams([]);
+      setRepositories([]);
       setTimeline({ selectedWorkstreamId: null, events: [] });
       return;
     }
 
-    const nextWorkstreams = await window.mergePilot.workstreams.list();
+    const [nextWorkstreams, nextRepositories] = await Promise.all([
+      window.mergePilot.workstreams.list(),
+      window.mergePilot.github.repositories.list()
+    ]);
     setWorkstreams(nextWorkstreams);
+    setRepositories(nextRepositories);
     const selected = preferredWorkstreamId ?? timeline.selectedWorkstreamId ?? nextWorkstreams[0]?.id ?? null;
     const selectedExists = selected ? nextWorkstreams.some((workstream) => workstream.id === selected) : false;
     const nextSelected = selectedExists ? selected : nextWorkstreams[0]?.id ?? null;
@@ -186,6 +211,7 @@ export function App() {
       const status = await window.mergePilot.orchestrator.stop();
       setOrchestratorStatus(status);
       setWorkstreams([]);
+      setRepositories([]);
       setTimeline({ selectedWorkstreamId: null, events: [] });
     } catch (caught) {
       setError(caught instanceof Error ? caught.message : "Unable to stop orchestrator.");
@@ -199,10 +225,23 @@ export function App() {
         await window.mergePilot.orchestrator.start();
       }
       const title = input?.title.trim() || `Workstream ${workstreams.length + 1}`;
+      const repository = input?.repositoryId
+        ? repositories.find((candidate) => candidate.id === input.repositoryId) ?? null
+        : null;
       const created = await window.mergePilot.workstreams.create({
         title,
         goal: input?.goal.trim() || "Coordinate and verify a local engineering goal through MergePilot.",
-        repo: input?.repo.trim() || "local/workspace",
+        repo: repository ? `${repository.owner}/${repository.name}` : input?.repo.trim() || "local/workspace",
+        githubRepository: repository
+          ? {
+              id: repository.id,
+              owner: repository.owner,
+              name: repository.name,
+              defaultBranch: repository.defaultBranch,
+              htmlUrl: repository.htmlUrl,
+              apiUrl: repository.apiUrl
+            }
+          : null,
         createdBy: "renderer",
         summary: input?.summary.trim() || "Created through the secure Electron bridge."
       });
@@ -263,6 +302,64 @@ export function App() {
     });
   }
 
+  async function submitRepository(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setError(null);
+    setRepositoryError(null);
+    setHumanAttentionMessage(null);
+    try {
+      if (orchestratorStatus?.state !== "running") {
+        await window.mergePilot.orchestrator.start();
+      }
+      const repository = await window.mergePilot.github.repositories.connect({
+        owner: repositoryFormState.owner,
+        name: repositoryFormState.name,
+        defaultBranch: repositoryFormState.defaultBranch,
+        htmlUrl: `https://github.com/${repositoryFormState.owner.trim()}/${repositoryFormState.name.trim()}`,
+        apiUrl: `https://api.github.com/repos/${repositoryFormState.owner.trim()}/${repositoryFormState.name.trim()}`
+      });
+      const selected = await window.mergePilot.github.repositories.select(repository.id);
+      setRepositoryFormState(emptyRepositoryForm);
+      setRepositoryDialogOpen(false);
+      setFormState((current) => ({ ...current, repo: `${selected.owner}/${selected.name}`, repositoryId: selected.id }));
+      await refreshOrchestrator(timeline.selectedWorkstreamId);
+    } catch (caught) {
+      const message = caught instanceof Error ? caught.message : "Unable to connect GitHub repository.";
+      setError(message);
+      setRepositoryError(message);
+      setHumanAttentionMessage(message);
+      setRepositoryDialogOpen(false);
+      if (selectedWorkstream) {
+        try {
+          await window.mergePilot.github.repositories.reportError({
+            workstreamId: selectedWorkstream.id,
+            repository: `${repositoryFormState.owner}/${repositoryFormState.name}`,
+            message,
+            reason: "repository_connection_failed"
+          });
+          setTimeline({
+            selectedWorkstreamId: selectedWorkstream.id,
+            events: await window.mergePilot.events.list(selectedWorkstream.id)
+          });
+        } catch {
+          // Keep the visible human attention message even if there is no persisted workstream event yet.
+        }
+      }
+    }
+  }
+
+  function selectRepository(repositoryId: string) {
+    const repository = repositories.find((candidate) => candidate.id === repositoryId) ?? null;
+    setFormState((current) => ({
+      ...current,
+      repositoryId,
+      repo: repository ? `${repository.owner}/${repository.name}` : current.repo
+    }));
+    if (repository) {
+      void window.mergePilot.github.repositories.select(repository.id).then(() => refreshOrchestrator(timeline.selectedWorkstreamId));
+    }
+  }
+
   const commandActions = useMemo(
     () => [
       {
@@ -276,6 +373,12 @@ export function App() {
         description: "Toggle the local coordinator process",
         icon: isRunning ? SquareIcon : PlayIcon,
         run: () => void (isRunning ? stopOrchestrator() : startOrchestrator())
+      },
+      {
+        label: "Connect GitHub repo",
+        description: "Add or select a repository scope",
+        icon: GitPullRequestIcon,
+        run: () => setRepositoryDialogOpen(true)
       },
       {
         label: "Open settings",
@@ -382,12 +485,27 @@ export function App() {
               <SquareIcon aria-hidden="true" />
               Stop
             </Button>
+            <Dialog open={repositoryDialogOpen} onOpenChange={setRepositoryDialogOpen}>
+              <DialogTrigger render={<Button variant="outline" />}>
+                <GitPullRequestIcon aria-hidden="true" />
+                Connect GitHub repo
+              </DialogTrigger>
+              <RepositoryDialog error={repositoryError} formState={repositoryFormState} onSubmit={submitRepository} setFormState={setRepositoryFormState} />
+            </Dialog>
             <Dialog open={newWorkstreamOpen} onOpenChange={setNewWorkstreamOpen}>
               <DialogTrigger render={<Button />}>
                 <PlusIcon aria-hidden="true" />
                 New Workstream
               </DialogTrigger>
-              <NewWorkstreamDialog formState={formState} setFormState={setFormState} onGoalChange={updateGoalPrompt} onSubmit={submitWorkstream} />
+              <NewWorkstreamDialog
+                formState={formState}
+                repositories={repositories}
+                selectedRepository={selectedRepository}
+                setFormState={setFormState}
+                onGoalChange={updateGoalPrompt}
+                onRepositoryChange={selectRepository}
+                onSubmit={submitWorkstream}
+              />
             </Dialog>
           </div>
         </header>
@@ -507,6 +625,41 @@ export function App() {
               )}
             </Panel>
 
+            <Panel className="mp-github-repositories" role="region" aria-label="GitHub repositories">
+              <div className="mp-section-heading">
+                <div>
+                  <p className="mp-eyebrow">GitHub integration</p>
+                  <h3>Repositories</h3>
+                </div>
+                <Button variant="outline" onClick={() => setRepositoryDialogOpen(true)}>
+                  <GitPullRequestIcon aria-hidden="true" />
+                  Add repository
+                </Button>
+              </div>
+              <div className="mp-repository-list">
+                {repositories.length > 0 ? (
+                  repositories.map((repository) => (
+                    <button
+                      className="mp-repository-row"
+                      data-selected={repository.selectedAt ? "true" : undefined}
+                      key={repository.id}
+                      onClick={() => selectRepository(repository.id)}
+                      type="button"
+                    >
+                      <span>{repository.owner}/{repository.name}</span>
+                      <small>Default branch {repository.defaultBranch}</small>
+                    </button>
+                  ))
+                ) : (
+                  <div className="mp-empty-state">
+                    <GitPullRequestIcon aria-hidden="true" />
+                    <strong>No GitHub repositories connected</strong>
+                    <p>Connect a repository to scope new workstreams to owner, name, and default branch metadata.</p>
+                  </div>
+                )}
+              </div>
+            </Panel>
+
             <Panel className="mp-timeline" id="timeline" aria-label="Event timeline">
               <div className="mp-section-heading">
                 <div>
@@ -553,7 +706,7 @@ export function App() {
               </p>
               <div className="mp-attention-placeholder">
                 <BellIcon aria-hidden="true" />
-                <span>No human action required right now.</span>
+                <span>{humanAttentionMessage ?? "No human action required right now."}</span>
               </div>
             </Panel>
 
@@ -630,12 +783,18 @@ function StatusLine({ icon, label, value }: { icon: ReactNode; label: string; va
 function NewWorkstreamDialog({
   formState,
   onGoalChange,
+  onRepositoryChange,
   onSubmit,
+  repositories,
+  selectedRepository,
   setFormState
 }: {
   formState: WorkstreamFormState;
   onGoalChange: (goal: string) => void;
+  onRepositoryChange: (repositoryId: string) => void;
   onSubmit: (event: FormEvent<HTMLFormElement>) => void;
+  repositories: GitHubRepositoryConnection[];
+  selectedRepository: GitHubRepositoryConnection | null;
   setFormState: (state: WorkstreamFormState) => void;
 }) {
   return (
@@ -668,12 +827,24 @@ function NewWorkstreamDialog({
           </div>
           <div>
             <Label htmlFor="workstream-repo">Repository</Label>
-            <Input
-              id="workstream-repo"
-              onChange={(event) => setFormState({ ...formState, repo: event.target.value })}
-              placeholder="ss-andrade/mergepilot"
-              value={formState.repo}
-            />
+            {repositories.length > 0 ? (
+              <Select id="workstream-repo" onChange={(event) => onRepositoryChange(event.target.value)} value={formState.repositoryId}>
+                <option value="">Select a connected repository</option>
+                {repositories.map((repository) => (
+                  <option key={repository.id} value={repository.id}>
+                    {repository.owner}/{repository.name}
+                  </option>
+                ))}
+              </Select>
+            ) : (
+              <Input
+                id="workstream-repo"
+                onChange={(event) => setFormState({ ...formState, repo: event.target.value, repositoryId: "" })}
+                placeholder="ss-andrade/mergepilot"
+                value={formState.repo}
+              />
+            )}
+            {selectedRepository ? <p className="mp-field-description">Default branch: {selectedRepository.defaultBranch}</p> : null}
           </div>
           <div>
             <Label htmlFor="workstream-summary">Summary</Label>
@@ -690,6 +861,50 @@ function NewWorkstreamDialog({
           <Button type="submit">
             <PlusIcon aria-hidden="true" />
             Create workstream
+          </Button>
+        </DialogFooter>
+      </form>
+    </DialogContent>
+  );
+}
+
+function RepositoryDialog({
+  error,
+  formState,
+  onSubmit,
+  setFormState
+}: {
+  error: string | null;
+  formState: GitHubRepositoryFormState;
+  onSubmit: (event: FormEvent<HTMLFormElement>) => void;
+  setFormState: (state: GitHubRepositoryFormState) => void;
+}) {
+  return (
+    <DialogContent>
+      <form onSubmit={onSubmit}>
+        <DialogHeader>
+          <DialogTitle>Connect GitHub repository</DialogTitle>
+          <DialogDescription>Store owner, repository name, and default branch metadata for workstream scoping.</DialogDescription>
+        </DialogHeader>
+        <DialogBody className="mp-form-grid">
+          <div>
+            <Label htmlFor="github-owner">Owner</Label>
+            <Input id="github-owner" onChange={(event) => setFormState({ ...formState, owner: event.target.value })} placeholder="ss-andrade" required value={formState.owner} />
+          </div>
+          <div>
+            <Label htmlFor="github-name">Repository name</Label>
+            <Input id="github-name" onChange={(event) => setFormState({ ...formState, name: event.target.value })} placeholder="mergepilot" required value={formState.name} />
+          </div>
+          <div>
+            <Label htmlFor="github-default-branch">Default branch</Label>
+            <Input id="github-default-branch" onChange={(event) => setFormState({ ...formState, defaultBranch: event.target.value })} placeholder="main" required value={formState.defaultBranch} />
+          </div>
+        </DialogBody>
+        <DialogFooter>
+          <DialogClose render={<Button variant="outline" />}>Cancel</DialogClose>
+          <Button type="submit">
+            <GitPullRequestIcon aria-hidden="true" />
+            Connect repository
           </Button>
         </DialogFooter>
       </form>

--- a/apps/web/src/global.d.ts
+++ b/apps/web/src/global.d.ts
@@ -46,6 +46,7 @@ interface Workstream {
   goal: string;
   status: WorkstreamStatus;
   repo: string;
+  githubRepository: WorkstreamGitHubRepositoryScope | null;
   createdBy: string;
   summary: string | null;
   createdAt: string;
@@ -56,8 +57,45 @@ interface CreateWorkstreamInput {
   title: string;
   goal: string;
   repo: string;
+  githubRepository?: WorkstreamGitHubRepositoryScope | null;
   createdBy: string;
   summary?: string | null;
+}
+
+interface GitHubRepositoryConnection {
+  id: string;
+  owner: string;
+  name: string;
+  defaultBranch: string;
+  htmlUrl: string | null;
+  apiUrl: string | null;
+  connectedAt: string;
+  updatedAt: string;
+  selectedAt: string | null;
+}
+
+interface WorkstreamGitHubRepositoryScope {
+  id?: string;
+  owner: string;
+  name: string;
+  defaultBranch: string;
+  htmlUrl?: string | null;
+  apiUrl?: string | null;
+}
+
+interface ConnectGitHubRepositoryInput {
+  owner: string;
+  name: string;
+  defaultBranch: string;
+  htmlUrl?: string | null;
+  apiUrl?: string | null;
+}
+
+interface ReportGitHubRepositoryConnectionErrorInput {
+  workstreamId: string;
+  repository: string;
+  message: string;
+  reason: string;
 }
 
 interface WorkstreamEvent {
@@ -93,6 +131,14 @@ interface MergePilotDesktopApi {
     list(): Promise<Workstream[]>;
     get(id: string): Promise<Workstream | null>;
     updateStatus(id: string, status: WorkstreamStatus): Promise<Workstream>;
+  };
+  github: {
+    repositories: {
+      connect(input: ConnectGitHubRepositoryInput): Promise<GitHubRepositoryConnection>;
+      list(): Promise<GitHubRepositoryConnection[]>;
+      select(id: string): Promise<GitHubRepositoryConnection>;
+      reportError(input: ReportGitHubRepositoryConnectionErrorInput): Promise<WorkstreamEvent>;
+    };
   };
   events: {
     append(input: AppendWorkstreamEventInput): Promise<WorkstreamEvent>;

--- a/packages/orchestrator/src/index.ts
+++ b/packages/orchestrator/src/index.ts
@@ -10,18 +10,22 @@ export type {
   AgentRun,
   AgentRunStatus,
   AppendWorkstreamEventInput,
+  ConnectGitHubRepositoryInput,
   CreateAgentRunInput,
   CreatePlanInput,
   CreateWorkstreamInput,
+  GitHubRepositoryConnection,
   LocalOrchestratorService,
   OrchestratorState,
   OrchestratorStatus,
   OrchestratorStore,
   Plan,
   PlanStatus,
+  ReportGitHubRepositoryConnectionErrorInput,
   Workstream,
   WorkstreamEvent,
   WorkstreamEventType,
+  WorkstreamGitHubRepositoryScope,
   WorkstreamStatus
 } from "./types.js";
 export { WORKSTREAM_EVENT_TYPES } from "./types.js";

--- a/packages/orchestrator/src/service.ts
+++ b/packages/orchestrator/src/service.ts
@@ -1,12 +1,14 @@
 import path from "node:path";
 import {
   AppendWorkstreamEventInput,
+  ConnectGitHubRepositoryInput,
   CreateAgentRunInput,
   CreatePlanInput,
   CreateWorkstreamInput,
   LocalOrchestratorService,
   OrchestratorStatus,
   OrchestratorStore,
+  ReportGitHubRepositoryConnectionErrorInput,
   WorkstreamStatus
 } from "./types.js";
 import { createSqliteOrchestratorStore } from "./sqlite-store.js";
@@ -58,6 +60,22 @@ export class InProcessLocalOrchestrator implements LocalOrchestratorService {
 
   updateWorkstreamStatus(id: string, nextStatus: WorkstreamStatus) {
     return this.requireStore().updateWorkstreamStatus(id, nextStatus);
+  }
+
+  connectGitHubRepository(input: ConnectGitHubRepositoryInput) {
+    return this.requireStore().connectGitHubRepository(input);
+  }
+
+  listGitHubRepositories() {
+    return this.requireStore().listGitHubRepositories();
+  }
+
+  selectGitHubRepository(id: string) {
+    return this.requireStore().selectGitHubRepository(id);
+  }
+
+  recordGitHubRepositoryConnectionError(input: ReportGitHubRepositoryConnectionErrorInput) {
+    return this.requireStore().recordGitHubRepositoryConnectionError(input);
   }
 
   appendEvent(input: AppendWorkstreamEventInput) {

--- a/packages/orchestrator/src/sqlite-store.ts
+++ b/packages/orchestrator/src/sqlite-store.ts
@@ -5,13 +5,17 @@ import { randomUUID } from "node:crypto";
 import {
   AgentRun,
   AppendWorkstreamEventInput,
+  ConnectGitHubRepositoryInput,
   CreateAgentRunInput,
   CreatePlanInput,
   CreateWorkstreamInput,
+  GitHubRepositoryConnection,
   OrchestratorStore,
   Plan,
+  ReportGitHubRepositoryConnectionErrorInput,
   Workstream,
   WorkstreamEvent,
+  WorkstreamGitHubRepositoryScope,
   WORKSTREAM_EVENT_TYPES,
   WorkstreamEventType
 } from "./types.js";
@@ -20,6 +24,9 @@ import {
   normalizeOptionalString,
   requireAgentRunStatus,
   requireEventType,
+  requireGitHubDefaultBranch,
+  requireGitHubOwner,
+  requireGitHubRepositoryName,
   requireId,
   requirePlanStatus,
   requireString,
@@ -32,10 +39,11 @@ export interface SqliteStoreOptions {
   databaseFileName?: string;
 }
 
-type WorkstreamRow = Omit<Workstream, "createdBy" | "createdAt" | "updatedAt"> & {
+type WorkstreamRow = Omit<Workstream, "createdBy" | "createdAt" | "updatedAt" | "githubRepository"> & {
   created_by: string;
   created_at: string;
   updated_at: string;
+  github_repository_json: string | null;
 };
 
 type EventRow = Omit<WorkstreamEvent, "workstreamId" | "createdAt" | "payload"> & {
@@ -63,6 +71,15 @@ type AgentRunRow = Omit<
   updated_at: string;
 };
 
+type GitHubRepositoryRow = Omit<GitHubRepositoryConnection, "defaultBranch" | "htmlUrl" | "apiUrl" | "connectedAt" | "updatedAt" | "selectedAt"> & {
+  default_branch: string;
+  html_url: string | null;
+  api_url: string | null;
+  connected_at: string;
+  updated_at: string;
+  selected_at: string | null;
+};
+
 const eventTypeSqlList = WORKSTREAM_EVENT_TYPES.map((type) => `'${type}'`).join(", ");
 
 export class SqliteOrchestratorStore implements OrchestratorStore {
@@ -81,12 +98,15 @@ export class SqliteOrchestratorStore implements OrchestratorStore {
 
   createWorkstream(input: CreateWorkstreamInput): Workstream {
     const now = new Date().toISOString();
+    const githubRepository = normalizeGitHubRepositoryScope(input.githubRepository);
+    const repo = githubRepository ? `${githubRepository.owner}/${githubRepository.name}` : requireString(input.repo, "repo", 2048);
     const workstream: Workstream = {
       id: randomUUID(),
       title: requireString(input.title, "title", 160),
       goal: requireString(input.goal, "goal", 5000),
       status: "draft",
-      repo: requireString(input.repo, "repo", 2048),
+      repo,
+      githubRepository,
       createdBy: requireString(input.createdBy, "createdBy", 160),
       summary: normalizeOptionalString(input.summary, 5000),
       createdAt: now,
@@ -95,10 +115,17 @@ export class SqliteOrchestratorStore implements OrchestratorStore {
 
     this.db
       .prepare(
-        `INSERT INTO workstreams (id, title, goal, status, repo, created_by, summary, created_at, updated_at)
-         VALUES (@id, @title, @goal, @status, @repo, @createdBy, @summary, @createdAt, @updatedAt)`
+        `INSERT INTO workstreams (
+           id, title, goal, status, repo, github_repository_json, created_by, summary, created_at, updated_at
+         )
+         VALUES (
+           @id, @title, @goal, @status, @repo, @githubRepositoryJson, @createdBy, @summary, @createdAt, @updatedAt
+         )`
       )
-      .run(workstream);
+      .run({
+        ...workstream,
+        githubRepositoryJson: githubRepository ? JSON.stringify(githubRepository) : null
+      });
 
     return workstream;
   }
@@ -137,6 +164,89 @@ export class SqliteOrchestratorStore implements OrchestratorStore {
       status,
       updatedAt
     };
+  }
+
+  connectGitHubRepository(input: ConnectGitHubRepositoryInput): GitHubRepositoryConnection {
+    const now = new Date().toISOString();
+    const owner = requireGitHubOwner(input.owner);
+    const name = requireGitHubRepositoryName(input.name);
+    const existing = this.db
+      .prepare("SELECT * FROM github_repositories WHERE owner = ? AND name = ?")
+      .get(owner, name) as GitHubRepositoryRow | undefined;
+    const record = {
+      id: existing?.id ?? randomUUID(),
+      owner,
+      name,
+      defaultBranch: requireGitHubDefaultBranch(input.defaultBranch),
+      htmlUrl: normalizeOptionalString(input.htmlUrl, 2048),
+      apiUrl: normalizeOptionalString(input.apiUrl, 2048),
+      connectedAt: existing?.connected_at ?? now,
+      updatedAt: now,
+      selectedAt: existing?.selected_at ?? null
+    };
+
+    this.db
+      .prepare(
+        `INSERT INTO github_repositories (
+           id, owner, name, default_branch, html_url, api_url, connected_at, updated_at, selected_at
+         )
+         VALUES (
+           @id, @owner, @name, @defaultBranch, @htmlUrl, @apiUrl, @connectedAt, @updatedAt, @selectedAt
+         )
+         ON CONFLICT(owner, name) DO UPDATE SET
+           default_branch = excluded.default_branch,
+           html_url = excluded.html_url,
+           api_url = excluded.api_url,
+           updated_at = excluded.updated_at`
+      )
+      .run(record);
+
+    return record;
+  }
+
+  listGitHubRepositories(): GitHubRepositoryConnection[] {
+    const rows = this.db
+      .prepare("SELECT * FROM github_repositories ORDER BY selected_at DESC NULLS LAST, updated_at DESC, owner ASC, name ASC")
+      .all() as GitHubRepositoryRow[];
+    return rows.map(mapGitHubRepositoryRow);
+  }
+
+  selectGitHubRepository(id: string): GitHubRepositoryConnection {
+    const repositoryId = requireId(id, "repositoryId");
+    const current = this.db.prepare("SELECT * FROM github_repositories WHERE id = ?").get(repositoryId) as
+      | GitHubRepositoryRow
+      | undefined;
+    if (!current) {
+      throw new Error(`GitHub repository ${repositoryId} was not found.`);
+    }
+
+    const selectedAt = new Date().toISOString();
+    this.db.transaction(() => {
+      this.db.prepare("UPDATE github_repositories SET selected_at = NULL").run();
+      this.db
+        .prepare("UPDATE github_repositories SET selected_at = ?, updated_at = ? WHERE id = ?")
+        .run(selectedAt, selectedAt, repositoryId);
+    })();
+
+    return {
+      ...mapGitHubRepositoryRow(current),
+      updatedAt: selectedAt,
+      selectedAt
+    };
+  }
+
+  recordGitHubRepositoryConnectionError(input: ReportGitHubRepositoryConnectionErrorInput): WorkstreamEvent {
+    return this.appendEvent({
+      workstreamId: input.workstreamId,
+      type: "human_action_required",
+      message: requireString(input.message, "message", 2000),
+      payload: {
+        integration: "github",
+        surface: "repository_connection",
+        repository: requireString(input.repository, "repository", 2048),
+        reason: requireString(input.reason, "reason", 160)
+      }
+    });
   }
 
   appendEvent(input: AppendWorkstreamEventInput): WorkstreamEvent {
@@ -296,6 +406,7 @@ export class SqliteOrchestratorStore implements OrchestratorStore {
           'cancelled'
         )),
         repo TEXT NOT NULL,
+        github_repository_json TEXT,
         created_by TEXT NOT NULL,
         summary TEXT,
         created_at TEXT NOT NULL,
@@ -337,13 +448,29 @@ export class SqliteOrchestratorStore implements OrchestratorStore {
         updated_at TEXT NOT NULL
       );
 
+      CREATE TABLE IF NOT EXISTS github_repositories (
+        id TEXT PRIMARY KEY,
+        owner TEXT NOT NULL,
+        name TEXT NOT NULL,
+        default_branch TEXT NOT NULL,
+        html_url TEXT,
+        api_url TEXT,
+        connected_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL,
+        selected_at TEXT,
+        UNIQUE(owner, name)
+      );
+
       CREATE INDEX IF NOT EXISTS idx_workstream_events_workstream_sequence
         ON workstream_events(workstream_id, sequence);
       CREATE INDEX IF NOT EXISTS idx_plans_workstream
         ON plans(workstream_id);
       CREATE INDEX IF NOT EXISTS idx_agent_runs_workstream
         ON agent_runs(workstream_id);
+      CREATE INDEX IF NOT EXISTS idx_github_repositories_selected
+        ON github_repositories(selected_at);
     `);
+    this.ensureWorkstreamsGitHubRepositorySchema();
     this.ensureWorkstreamEventsSchema();
     this.db.exec(`
       CREATE INDEX IF NOT EXISTS idx_workstream_events_workstream_sequence
@@ -396,6 +523,7 @@ export class SqliteOrchestratorStore implements OrchestratorStore {
             'cancelled'
           )),
           repo TEXT NOT NULL,
+          github_repository_json TEXT,
           created_by TEXT NOT NULL,
           summary TEXT,
           created_at TEXT NOT NULL,
@@ -439,8 +567,8 @@ export class SqliteOrchestratorStore implements OrchestratorStore {
       `);
 
       const insertWorkstream = this.db.prepare(`
-        INSERT INTO workstreams (id, title, goal, status, repo, created_by, summary, created_at, updated_at)
-        VALUES (@id, @title, @goal, @status, @repo, @createdBy, @summary, @createdAt, @updatedAt)
+        INSERT INTO workstreams (id, title, goal, status, repo, github_repository_json, created_by, summary, created_at, updated_at)
+        VALUES (@id, @title, @goal, @status, @repo, NULL, @createdBy, @summary, @createdAt, @updatedAt)
       `);
       for (const row of legacyWorkstreams) {
         const title = String(row.title ?? "Untitled workstream");
@@ -548,6 +676,13 @@ export class SqliteOrchestratorStore implements OrchestratorStore {
     recreateEvents();
   }
 
+  private ensureWorkstreamsGitHubRepositorySchema(): void {
+    const columns = this.db.prepare("PRAGMA table_info(workstreams)").all() as Array<{ name: string }>;
+    if (!columns.some((column) => column.name === "github_repository_json")) {
+      this.db.exec("ALTER TABLE workstreams ADD COLUMN github_repository_json TEXT;");
+    }
+  }
+
   private createEventImmutabilityTriggers(): void {
     this.db.exec(`
       CREATE TRIGGER IF NOT EXISTS trg_workstream_events_no_update
@@ -576,11 +711,45 @@ function mapWorkstreamRow(row: WorkstreamRow): Workstream {
     goal: row.goal,
     status: row.status,
     repo: row.repo,
+    githubRepository: row.github_repository_json === null ? null : JSON.parse(row.github_repository_json),
     createdBy: row.created_by,
     summary: row.summary,
     createdAt: row.created_at,
     updatedAt: row.updated_at
   };
+}
+
+function mapGitHubRepositoryRow(row: GitHubRepositoryRow): GitHubRepositoryConnection {
+  return {
+    id: row.id,
+    owner: row.owner,
+    name: row.name,
+    defaultBranch: row.default_branch,
+    htmlUrl: row.html_url,
+    apiUrl: row.api_url,
+    connectedAt: row.connected_at,
+    updatedAt: row.updated_at,
+    selectedAt: row.selected_at
+  };
+}
+
+function normalizeGitHubRepositoryScope(
+  input: WorkstreamGitHubRepositoryScope | GitHubRepositoryConnection | null | undefined
+): WorkstreamGitHubRepositoryScope | null {
+  if (!input) {
+    return null;
+  }
+  const scope: WorkstreamGitHubRepositoryScope = {
+    owner: requireGitHubOwner(input.owner),
+    name: requireGitHubRepositoryName(input.name),
+    defaultBranch: requireGitHubDefaultBranch(input.defaultBranch),
+    htmlUrl: normalizeOptionalString(input.htmlUrl, 2048),
+    apiUrl: normalizeOptionalString(input.apiUrl, 2048)
+  };
+  if (input.id) {
+    scope.id = requireId(input.id, "repositoryId");
+  }
+  return scope;
 }
 
 function mapEventRow(row: EventRow): WorkstreamEvent {

--- a/packages/orchestrator/src/types.ts
+++ b/packages/orchestrator/src/types.ts
@@ -38,6 +38,7 @@ export interface Workstream {
   goal: string;
   status: WorkstreamStatus;
   repo: string;
+  githubRepository: WorkstreamGitHubRepositoryScope | null;
   createdBy: string;
   summary: string | null;
   createdAt: string;
@@ -48,8 +49,45 @@ export interface CreateWorkstreamInput {
   title: string;
   goal: string;
   repo: string;
+  githubRepository?: WorkstreamGitHubRepositoryScope | null;
   createdBy: string;
   summary?: string | null;
+}
+
+export interface GitHubRepositoryConnection {
+  id: string;
+  owner: string;
+  name: string;
+  defaultBranch: string;
+  htmlUrl: string | null;
+  apiUrl: string | null;
+  connectedAt: string;
+  updatedAt: string;
+  selectedAt: string | null;
+}
+
+export interface WorkstreamGitHubRepositoryScope {
+  id?: string;
+  owner: string;
+  name: string;
+  defaultBranch: string;
+  htmlUrl?: string | null;
+  apiUrl?: string | null;
+}
+
+export interface ConnectGitHubRepositoryInput {
+  owner: string;
+  name: string;
+  defaultBranch: string;
+  htmlUrl?: string | null;
+  apiUrl?: string | null;
+}
+
+export interface ReportGitHubRepositoryConnectionErrorInput {
+  workstreamId: string;
+  repository: string;
+  message: string;
+  reason: string;
 }
 
 export interface WorkstreamEvent {
@@ -114,6 +152,10 @@ export interface OrchestratorStore {
   listWorkstreams(): Workstream[];
   getWorkstream(id: string): Workstream | null;
   updateWorkstreamStatus(id: string, nextStatus: WorkstreamStatus): Workstream;
+  connectGitHubRepository(input: ConnectGitHubRepositoryInput): GitHubRepositoryConnection;
+  listGitHubRepositories(): GitHubRepositoryConnection[];
+  selectGitHubRepository(id: string): GitHubRepositoryConnection;
+  recordGitHubRepositoryConnectionError(input: ReportGitHubRepositoryConnectionErrorInput): WorkstreamEvent;
   appendEvent(input: AppendWorkstreamEventInput): WorkstreamEvent;
   listEvents(workstreamId: string): WorkstreamEvent[];
   createPlan(input: CreatePlanInput): Plan;

--- a/packages/orchestrator/src/validation.ts
+++ b/packages/orchestrator/src/validation.ts
@@ -28,6 +28,9 @@ const allowedWorkstreamTransitions: Record<string, Set<string>> = {
 };
 const planStatuses = new Set(["draft", "approved", "rejected", "superseded"]);
 const agentRunStatuses = new Set(["queued", "running", "completed", "failed", "cancelled"]);
+const githubOwnerPattern = /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$/;
+const githubRepositoryNamePattern = /^[A-Za-z0-9._-]{1,100}$/;
+const gitRefNamePattern = /^[A-Za-z0-9][A-Za-z0-9._/-]{0,249}$/;
 
 export function normalizeOptionalString(value: string | null | undefined, maxLength: number): string | null {
   if (value === undefined || value === null) {
@@ -69,6 +72,30 @@ export function requireId(value: string, field = "id"): string {
     throw new Error(`${field} must be a valid local id.`);
   }
   return trimmed;
+}
+
+export function requireGitHubOwner(value: unknown): string {
+  const owner = requireString(value as string, "owner", 39);
+  if (!githubOwnerPattern.test(owner)) {
+    throw new Error("owner must be a valid GitHub owner.");
+  }
+  return owner;
+}
+
+export function requireGitHubRepositoryName(value: unknown): string {
+  const name = requireString(value as string, "name", 100);
+  if (!githubRepositoryNamePattern.test(name) || name === "." || name === ".." || name.toLowerCase() === ".git") {
+    throw new Error("name must be a valid GitHub repository name.");
+  }
+  return name;
+}
+
+export function requireGitHubDefaultBranch(value: unknown): string {
+  const branch = requireString(value as string, "defaultBranch", 250);
+  if (!gitRefNamePattern.test(branch) || branch.includes("..") || branch.endsWith("/") || branch.endsWith(".")) {
+    throw new Error("defaultBranch must be a valid Git branch name.");
+  }
+  return branch;
 }
 
 export function requireEventType(value: string): WorkstreamEventType {

--- a/packages/orchestrator/test/persistence.test.ts
+++ b/packages/orchestrator/test/persistence.test.ts
@@ -18,6 +18,138 @@ afterEach(async () => {
 });
 
 describe("SqliteOrchestratorStore", () => {
+  it("connects, selects, and persists GitHub repositories", async () => {
+    const dataDir = await createTempDir();
+    const first = createSqliteOrchestratorStore({ dataDir });
+
+    const connected = first.connectGitHubRepository({
+      owner: " ss-andrade ",
+      name: " mergepilot ",
+      defaultBranch: " main ",
+      htmlUrl: "https://github.com/ss-andrade/mergepilot",
+      apiUrl: "https://api.github.com/repos/ss-andrade/mergepilot"
+    });
+
+    expect(connected).toEqual({
+      id: expect.any(String),
+      owner: "ss-andrade",
+      name: "mergepilot",
+      defaultBranch: "main",
+      htmlUrl: "https://github.com/ss-andrade/mergepilot",
+      apiUrl: "https://api.github.com/repos/ss-andrade/mergepilot",
+      connectedAt: expect.any(String),
+      updatedAt: connected.connectedAt,
+      selectedAt: null
+    });
+
+    expect(first.selectGitHubRepository(connected.id)).toMatchObject({
+      id: connected.id,
+      selectedAt: expect.any(String)
+    });
+    first.close();
+
+    const second = createSqliteOrchestratorStore({ dataDir });
+    expect(second.listGitHubRepositories()).toEqual([
+      expect.objectContaining({
+        id: connected.id,
+        owner: "ss-andrade",
+        name: "mergepilot",
+        defaultBranch: "main",
+        selectedAt: expect.any(String)
+      })
+    ]);
+    second.close();
+  });
+
+  it("stores typed GitHub repository scope on workstreams while preserving canonical repo", async () => {
+    const dataDir = await createTempDir();
+    const store = createSqliteOrchestratorStore({ dataDir });
+    const repository = store.connectGitHubRepository({
+      owner: "ss-andrade",
+      name: "mergepilot",
+      defaultBranch: "main"
+    });
+
+    const workstream = store.createWorkstream({
+      title: "GitHub scoped work",
+      goal: "Track work against a connected GitHub repository.",
+      repo: "ignored/manual-value",
+      githubRepository: repository,
+      createdBy: "hermes"
+    });
+
+    expect(workstream).toMatchObject({
+      repo: "ss-andrade/mergepilot",
+      githubRepository: {
+        id: repository.id,
+        owner: "ss-andrade",
+        name: "mergepilot",
+        defaultBranch: "main",
+        htmlUrl: null,
+        apiUrl: null
+      }
+    });
+    expect(store.getWorkstream(workstream.id)).toMatchObject({
+      repo: "ss-andrade/mergepilot",
+      githubRepository: {
+        id: repository.id,
+        owner: "ss-andrade",
+        name: "mergepilot",
+        defaultBranch: "main"
+      }
+    });
+    store.close();
+  });
+
+  it("validates GitHub repository connection input", async () => {
+    const dataDir = await createTempDir();
+    const store = createSqliteOrchestratorStore({ dataDir });
+
+    expect(() =>
+      store.connectGitHubRepository({ owner: "bad owner", name: "mergepilot", defaultBranch: "main" })
+    ).toThrow(/owner/i);
+    expect(() =>
+      store.connectGitHubRepository({ owner: "ss-andrade", name: ".git", defaultBranch: "main" })
+    ).toThrow(/name/i);
+    expect(() =>
+      store.connectGitHubRepository({ owner: "ss-andrade", name: "mergepilot", defaultBranch: "feature branch" })
+    ).toThrow(/defaultBranch/i);
+    expect(store.listGitHubRepositories()).toEqual([]);
+    store.close();
+  });
+
+  it("surfaces GitHub integration errors as human action required timeline events", async () => {
+    const dataDir = await createTempDir();
+    const store = createSqliteOrchestratorStore({ dataDir });
+    const workstream = store.createWorkstream({
+      title: "Repository access",
+      goal: "Connect a repository that requires attention.",
+      repo: "ss-andrade/mergepilot",
+      createdBy: "hermes"
+    });
+
+    const event = store.recordGitHubRepositoryConnectionError({
+      workstreamId: workstream.id,
+      repository: "ss-andrade/mergepilot",
+      message: "GitHub repository access needs attention.",
+      reason: "not_found"
+    });
+
+    expect(event).toMatchObject({
+      workstreamId: workstream.id,
+      type: "human_action_required",
+      message: "GitHub repository access needs attention.",
+      payload: {
+        integration: "github",
+        surface: "repository_connection",
+        repository: "ss-andrade/mergepilot",
+        reason: "not_found"
+      }
+    });
+    expect(store.listEvents(workstream.id)).toEqual([expect.objectContaining({ id: event.id })]);
+    store.close();
+  });
+
   it("persists workstreams across store instances", async () => {
     const dataDir = await createTempDir();
     const first = createSqliteOrchestratorStore({ dataDir });
@@ -158,6 +290,7 @@ describe("SqliteOrchestratorStore", () => {
       title: "Canonical model",
       goal: "Exercise issue two behavior.",
       repo: "ss-andrade/mergepilot",
+      githubRepository: null,
       createdBy: "hermes",
       summary: null,
       status: "draft",

--- a/packages/orchestrator/test/service.test.ts
+++ b/packages/orchestrator/test/service.test.ts
@@ -60,6 +60,32 @@ describe("LocalOrchestratorService", () => {
     expect(orchestrator.status()).toMatchObject({ state: "stopped" });
   });
 
+  it("serves GitHub repository connections through the local service", async () => {
+    const dataDir = await createTempDir();
+    const orchestrator = createLocalOrchestrator({ dataDir });
+    await orchestrator.start();
+
+    const repository = orchestrator.connectGitHubRepository({
+      owner: "ss-andrade",
+      name: "mergepilot",
+      defaultBranch: "main"
+    });
+
+    expect(orchestrator.selectGitHubRepository(repository.id)).toMatchObject({
+      id: repository.id,
+      selectedAt: expect.any(String)
+    });
+    expect(orchestrator.listGitHubRepositories()).toEqual([
+      expect.objectContaining({
+        owner: "ss-andrade",
+        name: "mergepilot",
+        defaultBranch: "main"
+      })
+    ]);
+
+    await orchestrator.stop();
+  });
+
   it("rejects data operations while stopped", async () => {
     const orchestrator = createLocalOrchestrator({ dataDir: await createTempDir() });
 

--- a/tests/runtime/renderer.spec.ts
+++ b/tests/runtime/renderer.spec.ts
@@ -14,6 +14,19 @@ test("web renderer runs against a mocked mergePilot bridge", async ({ page }) =>
     let running = false;
     let sequence = 0;
     const createCalls: CreateWorkstreamInput[] = [];
+    const repositories: GitHubRepositoryConnection[] = [
+      {
+        id: "repo-existing",
+        owner: "ss-andrade",
+        name: "mergepilot",
+        defaultBranch: "main",
+        htmlUrl: "https://github.com/ss-andrade/mergepilot",
+        apiUrl: "https://api.github.com/repos/ss-andrade/mergepilot",
+        connectedAt: now,
+        updatedAt: now,
+        selectedAt: now
+      }
+    ];
     const workstreams: Workstream[] = [
       {
         id: "ws-empty",
@@ -116,6 +129,58 @@ test("web renderer runs against a mocked mergePilot bridge", async ({ page }) =>
           return workstream;
         }
       },
+      github: {
+        repositories: {
+          connect: async (input) => {
+            if (input.owner === "missing") {
+              throw new Error("Repository not found or inaccessible.");
+            }
+            const created: GitHubRepositoryConnection = {
+              id: `repo-${repositories.length + 1}`,
+              owner: input.owner,
+              name: input.name,
+              defaultBranch: input.defaultBranch,
+              htmlUrl: input.htmlUrl ?? null,
+              apiUrl: input.apiUrl ?? null,
+              connectedAt: now,
+              updatedAt: now,
+              selectedAt: null
+            };
+            repositories.push(created);
+            return created;
+          },
+          list: async () => [...repositories],
+          select: async (id) => {
+            const selected = repositories.find((repository) => repository.id === id);
+            if (!selected) {
+              throw new Error(`Missing repository ${id}`);
+            }
+            for (const repository of repositories) {
+              repository.selectedAt = repository.id === id ? now : null;
+            }
+            return selected;
+          },
+          reportError: async (input) => {
+            const created: WorkstreamEvent = {
+              id: `event-${sequence + 1}`,
+              workstreamId: input.workstreamId,
+              sequence: sequence + 1,
+              type: "human_action_required",
+              message: input.message,
+              payload: {
+                integration: "github",
+                surface: "repository_connection",
+                repository: input.repository,
+                reason: input.reason
+              },
+              createdAt: now
+            };
+            sequence += 1;
+            events.push(created);
+            return created;
+          }
+        }
+      },
       events: {
         append: async (input) => {
           const created: WorkstreamEvent = {
@@ -150,6 +215,8 @@ test("web renderer runs against a mocked mergePilot bridge", async ({ page }) =>
   await expect(page.getByRole("region", { name: "Workstream detail" })).toContainText("Show canonical events for an existing workstream.");
   await expect(page.getByRole("region", { name: "Workstream detail" })).toContainText("ss-andrade/mergepilot");
   await expect(page.getByRole("region", { name: "Workstream detail" })).toContainText("renderer");
+  await expect(page.getByRole("region", { name: "GitHub repositories" })).toContainText("ss-andrade/mergepilot");
+  await expect(page.getByRole("region", { name: "GitHub repositories" })).toContainText("main");
   await expect(page.getByRole("region", { name: "Event timeline" })).toContainText("plan_created");
   await expect(page.getByRole("region", { name: "Event timeline" })).toContainText("human_action_required");
   await expect(page.getByRole("region", { name: "Human attention" })).toContainText("Plan approvals, blockers, and access requests");
@@ -162,7 +229,7 @@ test("web renderer runs against a mocked mergePilot bridge", async ({ page }) =>
   await page.getByLabel("Goal prompt").fill("Build a basic workstream UI with a list, detail page, and human attention placeholder.");
   await expect(page.getByLabel("Title")).toHaveValue("Build a basic workstream UI");
   await page.getByLabel("Summary").fill("Basic workstream UI is ready to track.");
-  await page.getByLabel("Repository").fill("ss-andrade/mergepilot");
+  await page.getByLabel("Repository").selectOption("repo-existing");
   await page.getByRole("button", { name: "Create workstream" }).click();
 
   await expect(page.getByRole("heading", { level: 2, name: "Build a basic workstream UI" })).toBeVisible();
@@ -172,8 +239,29 @@ test("web renderer runs against a mocked mergePilot bridge", async ({ page }) =>
     title: "Build a basic workstream UI",
     goal: "Build a basic workstream UI with a list, detail page, and human attention placeholder.",
     repo: "ss-andrade/mergepilot",
+    githubRepository: {
+      id: "repo-existing",
+      owner: "ss-andrade",
+      name: "mergepilot",
+      defaultBranch: "main"
+    },
     createdBy: "renderer",
     summary: "Basic workstream UI is ready to track."
   });
+
+  await page.getByRole("button", { name: "Connect GitHub repo" }).click();
+  await page.getByLabel("Owner").fill("openai");
+  await page.getByLabel("Repository name").fill("codex");
+  await page.getByLabel("Default branch").fill("main");
+  await page.getByRole("button", { name: "Connect repository" }).click();
+  await expect(page.getByRole("region", { name: "GitHub repositories" })).toContainText("openai/codex");
+
+  await page.getByRole("button", { name: "Connect GitHub repo" }).click();
+  await page.getByLabel("Owner").fill("missing");
+  await page.getByLabel("Repository name").fill("private-repo");
+  await page.getByLabel("Default branch").fill("main");
+  await page.getByRole("button", { name: "Connect repository" }).click();
+  await expect(page.getByRole("alert")).toContainText("Repository not found or inaccessible.");
+  await expect(page.getByRole("region", { name: "Human attention" })).toContainText("Repository not found or inaccessible.");
   expect(runtimeFailures).toEqual([]);
 });


### PR DESCRIPTION
## Summary
- Adds persisted GitHub repository connections with owner/name/default branch metadata and selected repository state.
- Extends workstreams with optional typed GitHub repository scope while preserving the canonical repo string and migration compatibility.
- Exposes GitHub repository connect/list/select/error-report APIs through the desktop IPC/preload bridge and renderer globals.
- Adds a renderer repository panel, connect dialog, workstream repository selector, and human-attention surfacing for connection errors.

## TDD / Verification
- RED: Added failing tests first for repository persistence/selection/validation, service API exposure, IPC validation, and renderer repository selection/error behavior.
- GREEN: `npm run typecheck`
- GREEN: `npm run test`
- GREEN: `npm run build -w @mergepilot/web`
- GREEN: `npm run test:e2e:web`
- GREEN: `npm run verify`
- GREEN: `npm run test:e2e:electron` — exited 0; Electron runtime test skipped by Linux display preflight and native module rebuilt back to Node.
- GREEN: `git diff --check`
- GREEN: secret/dangerous API diff scan

## Review
- Independent review completed; no code blockers after verification. Reviewer noted the branch needed a commit before PR, handled here.

Closes #5
