### PR TITLE
feat: default desktop builds to Codex

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -7,11 +7,12 @@
     "dev": "concurrently -k -n renderer,electron -c cyan,magenta \"npm run dev -w @mergepilot/web\" \"npm run dev:electron\"",
     "dev:electron": "npm run build:main && wait-on tcp:5173 && cross-env VITE_DEV_SERVER_URL=http://localhost:5173 electron .",
     "build": "npm run build:main",
-    "build:main": "npm run build -w @mergepilot/orchestrator && tsc -b tsconfig.json --force",
-    "typecheck": "npm run build -w @mergepilot/orchestrator && tsc -p tsconfig.json --noEmit",
+    "build:main": "npm run build -w @mergepilot/agents && npm run build -w @mergepilot/orchestrator && npm run build -w @mergepilot/codex-adapter && tsc -b tsconfig.json --force",
+    "typecheck": "npm run build -w @mergepilot/agents && npm run build -w @mergepilot/orchestrator && npm run build -w @mergepilot/codex-adapter && tsc -p tsconfig.json --noEmit",
     "test": "vitest run"
   },
   "dependencies": {
+    "@mergepilot/codex-adapter": "0.0.0",
     "@mergepilot/orchestrator": "0.0.0",
     "@mergepilot/web": "0.0.0"
   },

--- a/apps/desktop/src/main/desktop-orchestrator.test.ts
+++ b/apps/desktop/src/main/desktop-orchestrator.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { createDesktopOrchestratorOptions } from "./desktop-orchestrator.js";
+
+describe("desktop orchestrator construction", () => {
+  it("uses Codex as the production build-agent adapter by default", () => {
+    const options = createDesktopOrchestratorOptions({ dataDir: "/tmp/mergepilot" });
+
+    expect(options.dataDir).toBe("/tmp/mergepilot");
+    expect(options.buildAgentAdapter).toMatchObject({
+      metadata: {
+        providerId: "codex",
+        displayName: "OpenAI Codex"
+      }
+    });
+    expect(options.buildAgentAdapter?.run).toEqual(expect.any(Function));
+  });
+
+  it("preserves deterministic adapter overrides for tests", () => {
+    const fakeAdapter = {
+      metadata: {
+        providerId: "fake-agent",
+        adapterId: "fake-build",
+        displayName: "Fake Build Agent",
+        capabilities: {
+          streamingEvents: true,
+          cancellation: true,
+          structuredResults: true,
+          sessionResume: false
+        }
+      },
+      detect: async () => ({ providerId: "fake-agent", status: "available" as const, checkedAt: "2026-05-04T00:00:00.000Z" }),
+      health: async () => ({ providerId: "fake-agent", status: "healthy" as const, checkedAt: "2026-05-04T00:00:00.000Z" }),
+      run: async () => {
+        throw new Error("not used");
+      }
+    };
+
+    const options = createDesktopOrchestratorOptions({
+      dataDir: "/tmp/mergepilot",
+      buildAgentAdapter: fakeAdapter
+    });
+
+    expect(options.buildAgentAdapter).toBe(fakeAdapter);
+  });
+});

--- a/apps/desktop/src/main/desktop-orchestrator.ts
+++ b/apps/desktop/src/main/desktop-orchestrator.ts
@@ -1,0 +1,26 @@
+import { CodexAdapter } from "@mergepilot/codex-adapter";
+import { createLocalOrchestrator } from "@mergepilot/orchestrator";
+import type {
+  BuildAgentRunnerOptions,
+  LocalOrchestratorOptions,
+  LocalOrchestratorService
+} from "@mergepilot/orchestrator";
+
+export interface DesktopOrchestratorConstructionOptions extends BuildAgentRunnerOptions {
+  dataDir: string;
+}
+
+export function createDesktopOrchestratorOptions(
+  options: DesktopOrchestratorConstructionOptions
+): LocalOrchestratorOptions {
+  return {
+    ...options,
+    buildAgentAdapter: options.buildAgentAdapter ?? new CodexAdapter()
+  };
+}
+
+export function createDesktopOrchestrator(
+  options: DesktopOrchestratorConstructionOptions
+): LocalOrchestratorService {
+  return createLocalOrchestrator(createDesktopOrchestratorOptions(options));
+}

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -1,7 +1,7 @@
 import { app, BrowserWindow, ipcMain, shell } from "electron";
-import { createLocalOrchestrator } from "@mergepilot/orchestrator";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { createDesktopOrchestrator } from "./desktop-orchestrator.js";
 import { registerOrchestratorIpcHandlers } from "./orchestrator-ipc.js";
 
 const rendererDevServerUrl = process.env.VITE_DEV_SERVER_URL;
@@ -36,7 +36,7 @@ if (userDataDirOverride) {
   app.setPath("userData", userDataDirOverride);
 }
 
-const orchestrator = createLocalOrchestrator({
+const orchestrator = createDesktopOrchestrator({
   dataDir: path.join(app.getPath("userData"), "orchestrator")
 });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
       "name": "@mergepilot/desktop",
       "version": "0.0.0",
       "dependencies": {
+        "@mergepilot/codex-adapter": "0.0.0",
         "@mergepilot/orchestrator": "0.0.0",
         "@mergepilot/web": "0.0.0"
       },

--- a/packages/orchestrator/src/index.ts
+++ b/packages/orchestrator/src/index.ts
@@ -7,6 +7,9 @@ export {
   InProcessLocalOrchestrator
 } from "./service.js";
 export type {
+  LocalOrchestratorOptions
+} from "./service.js";
+export type {
   AgentRun,
   AgentRunStatus,
   AppendWorkstreamEventInput,

--- a/packages/orchestrator/test/service.test.ts
+++ b/packages/orchestrator/test/service.test.ts
@@ -265,6 +265,70 @@ describe("LocalOrchestratorService", () => {
     await orchestrator.stop();
   });
 
+  it("surfaces build-agent adapter failures as human action instead of fake success", async () => {
+    const dataDir = await createTempDir();
+    const orchestrator = createLocalOrchestrator({
+      dataDir,
+      buildAgentAdapter: {
+        metadata: {
+          providerId: "codex",
+          adapterId: "codex",
+          displayName: "OpenAI Codex",
+          capabilities: {
+            streamingEvents: true,
+            cancellation: true,
+            structuredResults: false,
+            sessionResume: false
+          }
+        },
+        detect: async () => ({ providerId: "codex", status: "available", checkedAt: "2026-05-04T00:00:00.000Z" }),
+        health: async () => ({ providerId: "codex", status: "degraded", checkedAt: "2026-05-04T00:00:00.000Z" }),
+        run: vi.fn(async () => {
+          throw new Error("Codex CLI is not authenticated.");
+        })
+      }
+    });
+    await orchestrator.start();
+    const workstream = orchestrator.createWorkstream({
+      title: "Codex failure",
+      goal: "Surface Codex execution failures.",
+      repo: "ss-andrade/mergepilot",
+      createdBy: "hermes"
+    });
+    orchestrator.updateWorkstreamStatus(workstream.id, "planning");
+    const plan = orchestrator.proposePlan({ workstreamId: workstream.id });
+    orchestrator.approvePlan({ workstreamId: workstream.id, planId: plan.id });
+
+    const run = await orchestrator.startBuildAgentRun({ workstreamId: workstream.id });
+
+    expect(run).toMatchObject({
+      providerId: "codex",
+      adapterId: "codex",
+      status: "failed",
+      summary: "Codex CLI is not authenticated."
+    });
+    expect(orchestrator.getWorkstream(workstream.id)).toMatchObject({
+      status: "awaiting_user_input",
+      summary: "Codex CLI is not authenticated."
+    });
+    expect(orchestrator.listEvents(workstream.id)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "human_action_required",
+          message: "Build agent run failed.",
+          payload: expect.objectContaining({ runId: run.id, errorMessage: "Codex CLI is not authenticated." })
+        })
+      ])
+    );
+    expect(orchestrator.listEvents(workstream.id)).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: "agent_completed", payload: expect.objectContaining({ runId: run.id }) })
+      ])
+    );
+
+    await orchestrator.stop();
+  });
+
   it("opens a pull request from a completed build-agent run and links it to the timeline", async () => {
     const dataDir = await createTempDir();
     const pullRequestPublisher = {


### PR DESCRIPTION
## Summary
- Make the desktop app construct its local orchestrator with the real Codex build-agent adapter by default.
- Add a small desktop orchestrator factory so tests can assert production defaults while preserving deterministic adapter overrides.
- Add regression coverage that build-agent adapter failures become visible human-action blockers instead of fake success.

## Test Plan
- `npm run typecheck -w @mergepilot/desktop`
- `npm run test -w @mergepilot/desktop`
- `npm run typecheck -w @mergepilot/orchestrator`
- `npm run test -w @mergepilot/orchestrator -- --run test/service.test.ts`
- `npm run verify`
- `npm run test:e2e:web`
- `npm run test:e2e:electron`
- Independent blocker review: no blockers

Closes #33
