### PR TITLE
feat: publish real GitHub pull requests

### DIFF
--- a/apps/desktop/src/main/desktop-orchestrator.test.ts
+++ b/apps/desktop/src/main/desktop-orchestrator.test.ts
@@ -13,9 +13,10 @@ describe("desktop orchestrator construction", () => {
       }
     });
     expect(options.buildAgentAdapter?.run).toEqual(expect.any(Function));
+    expect(options.pullRequestPublisher?.constructor.name).toBe("GitHubCliPullRequestPublisher");
   });
 
-  it("preserves deterministic adapter overrides for tests", () => {
+  it("preserves deterministic adapter and publisher overrides for tests", () => {
     const fakeAdapter = {
       metadata: {
         providerId: "fake-agent",
@@ -34,12 +35,22 @@ describe("desktop orchestrator construction", () => {
         throw new Error("not used");
       }
     };
+    const fakePublisher = {
+      openPullRequest: async () => ({
+        branchName: "mergepilot/ws/build/run",
+        commitSha: "abc123",
+        prNumber: 1,
+        prUrl: "https://github.com/ss-andrade/mergepilot/pull/1"
+      })
+    };
 
     const options = createDesktopOrchestratorOptions({
       dataDir: "/tmp/mergepilot",
-      buildAgentAdapter: fakeAdapter
+      buildAgentAdapter: fakeAdapter,
+      pullRequestPublisher: fakePublisher
     });
 
     expect(options.buildAgentAdapter).toBe(fakeAdapter);
+    expect(options.pullRequestPublisher).toBe(fakePublisher);
   });
 });

--- a/apps/desktop/src/main/desktop-orchestrator.ts
+++ b/apps/desktop/src/main/desktop-orchestrator.ts
@@ -1,5 +1,5 @@
 import { CodexAdapter } from "@mergepilot/codex-adapter";
-import { createLocalOrchestrator } from "@mergepilot/orchestrator";
+import { GitHubCliPullRequestPublisher, createLocalOrchestrator } from "@mergepilot/orchestrator";
 import type {
   BuildAgentRunnerOptions,
   LocalOrchestratorOptions,
@@ -15,7 +15,8 @@ export function createDesktopOrchestratorOptions(
 ): LocalOrchestratorOptions {
   return {
     ...options,
-    buildAgentAdapter: options.buildAgentAdapter ?? new CodexAdapter()
+    buildAgentAdapter: options.buildAgentAdapter ?? new CodexAdapter(),
+    pullRequestPublisher: options.pullRequestPublisher ?? new GitHubCliPullRequestPublisher()
   };
 }
 

--- a/packages/orchestrator/src/index.ts
+++ b/packages/orchestrator/src/index.ts
@@ -4,9 +4,14 @@ export {
 } from "./sqlite-store.js";
 export {
   createLocalOrchestrator,
+  GitHubCliPullRequestPublisher,
   InProcessLocalOrchestrator
 } from "./service.js";
 export type {
+  GitHubCliCommandExecutor,
+  GitHubCliCommandOptions,
+  GitHubCliCommandResult,
+  GitHubCliPullRequestPublisherOptions,
   LocalOrchestratorOptions
 } from "./service.js";
 export type {

--- a/packages/orchestrator/src/service.ts
+++ b/packages/orchestrator/src/service.ts
@@ -45,6 +45,25 @@ export interface LocalOrchestratorOptions extends BuildAgentRunnerOptions {
   dataDir: string;
 }
 
+export interface GitHubCliPullRequestPublisherOptions {
+  command?: GitHubCliCommandExecutor;
+}
+
+export interface GitHubCliCommandOptions {
+  cwd: string;
+}
+
+export interface GitHubCliCommandResult {
+  stdout: string;
+  stderr?: string;
+}
+
+export type GitHubCliCommandExecutor = (
+  command: string,
+  args: string[],
+  options: GitHubCliCommandOptions
+) => Promise<GitHubCliCommandResult>;
+
 export class InProcessLocalOrchestrator implements LocalOrchestratorService {
   private store: OrchestratorStore | null = null;
   private readonly databasePath: string;
@@ -504,6 +523,181 @@ class DeterministicPullRequestPublisher implements PullRequestPublisher {
       prUrl: `https://github.com/${safeOwner}/${safeName}/pull/${prNumber}`
     };
   }
+}
+
+export class GitHubCliPullRequestPublisher implements PullRequestPublisher {
+  private readonly command: GitHubCliCommandExecutor;
+
+  constructor(options: GitHubCliPullRequestPublisherOptions = {}) {
+    this.command = options.command ?? execPublisherCommand;
+  }
+
+  async openPullRequest(input: Parameters<PullRequestPublisher["openPullRequest"]>[0]): Promise<{ branchName: string; commitSha: string; prNumber: number; prUrl: string }> {
+    const repo = requirePublishRepository(input.workstream);
+    const branchName = requirePublishBranch(input.agentRun.branchName);
+    const workspacePath = requirePublishWorkspace(input.agentRun.workspacePath);
+    const baseBranch = requirePublishBaseBranch(input.workstream.githubRepository?.defaultBranch ?? "main");
+    const title = boundedPublisherText(input.title, "Pull request title", 200);
+    const body = boundedPublisherText(input.body, "Pull request body", 4000);
+
+    const status = await this.run("inspect workspace changes", "git", ["status", "--porcelain"], workspacePath);
+    if (!status.stdout.trim()) {
+      throw new Error("No file changes were found in the build-agent workspace; no pull request was published.");
+    }
+    const origin = await this.run("verify workspace origin", "git", ["remote", "get-url", "origin"], workspacePath);
+    const originRepo = normalizeGitHubRemote(origin.stdout.trim());
+    if (originRepo !== repo) {
+      throw new Error("Build-agent workspace origin does not match the selected GitHub repository; no pull request was published.");
+    }
+    const pushOrigin = await this.run("verify workspace push origin", "git", ["remote", "get-url", "--push", "--all", "origin"], workspacePath);
+    const pushRepos = pushOrigin.stdout
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter(Boolean)
+      .map((line) => normalizeGitHubRemote(line));
+    if (pushRepos.length === 0 || pushRepos.some((pushRepo) => pushRepo !== repo)) {
+      throw new Error("Build-agent workspace push origin does not match the selected GitHub repository; no pull request was published.");
+    }
+
+    await this.run("verify GitHub CLI authentication", "gh", ["auth", "status"], workspacePath);
+    await this.run("create build-agent branch", "git", ["checkout", "-B", branchName], workspacePath);
+    await this.run("stage build-agent changes", "git", ["add", "-A"], workspacePath);
+    await this.run("commit build-agent changes", "git", ["commit", "-m", title, "-m", body], workspacePath);
+    const commit = await this.run("read published commit SHA", "git", ["rev-parse", "HEAD"], workspacePath);
+    const commitSha = commit.stdout.trim();
+    if (!/^[A-Fa-f0-9]{7,64}$/.test(commitSha)) {
+      throw new Error("Git did not return a valid commit SHA after committing build-agent changes.");
+    }
+    await this.run("push build-agent branch", "git", ["push", "--set-upstream", "origin", branchName], workspacePath);
+    const created = await this.run("create GitHub pull request", "gh", [
+      "pr",
+      "create",
+      "--repo",
+      repo,
+      "--base",
+      baseBranch,
+      "--head",
+      branchName,
+      "--title",
+      title,
+      "--body",
+      body
+    ], workspacePath);
+    const pullRequest = parsePullRequestCreateOutput(created.stdout);
+
+    return {
+      branchName,
+      commitSha,
+      prNumber: pullRequest.prNumber,
+      prUrl: pullRequest.prUrl
+    };
+  }
+
+  private async run(action: string, command: string, args: string[], cwd: string): Promise<GitHubCliCommandResult> {
+    try {
+      return await this.command(command, args, { cwd });
+    } catch (error) {
+      throw new Error(`Failed to ${action}: ${publisherErrorMessage(error)}`);
+    }
+  }
+}
+
+async function execPublisherCommand(command: string, args: string[], options: GitHubCliCommandOptions): Promise<GitHubCliCommandResult> {
+  const { stdout, stderr } = await execFileAsync(command, args, {
+    cwd: options.cwd,
+    timeout: 120000,
+    maxBuffer: 1024 * 1024
+  });
+  return { stdout, stderr };
+}
+
+function requirePublishRepository(workstream: Parameters<PullRequestPublisher["openPullRequest"]>[0]["workstream"]): string {
+  const repo = repositorySlug(workstream.repo);
+  if (!repo) {
+    throw new Error("Workstream repository must be a GitHub owner/name slug before publishing a pull request.");
+  }
+  if (workstream.githubRepository) {
+    const scopedRepo = repositorySlug(`${workstream.githubRepository.owner}/${workstream.githubRepository.name}`);
+    if (scopedRepo !== repo) {
+      throw new Error("Workstream repository does not match the connected GitHub repository scope.");
+    }
+    requirePublishBaseBranch(workstream.githubRepository.defaultBranch);
+  }
+  return repo;
+}
+
+function normalizeGitHubRemote(remoteUrl: string): string | null {
+  const url = remoteUrl.trim().replace(/\.git$/, "");
+  const https = url.match(/^https:\/\/github\.com\/([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+)$/i);
+  if (https) {
+    return `${https[1]}/${https[2]}`;
+  }
+  const ssh = url.match(/^git@github\.com:([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+)$/i);
+  if (ssh) {
+    return `${ssh[1]}/${ssh[2]}`;
+  }
+  const sshUrl = url.match(/^ssh:\/\/git@github\.com\/([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+)$/i);
+  if (sshUrl) {
+    return `${sshUrl[1]}/${sshUrl[2]}`;
+  }
+  return null;
+}
+
+function requirePublishBranch(branchName: string | null): string {
+  const branch = branchName?.trim();
+  if (!branch || branch.length > 200 || !/^[A-Za-z0-9._/-]+$/.test(branch) || branch.startsWith("/") || branch.endsWith("/") || branch.includes("..")) {
+    throw new Error("Completed build-agent run must include valid branch metadata before publishing a pull request.");
+  }
+  return branch;
+}
+
+function requirePublishWorkspace(workspacePath: string | null): string {
+  const workspace = workspacePath?.trim();
+  if (!workspace) {
+    throw new Error("Completed build-agent run must include a workspace path before publishing a pull request.");
+  }
+  return workspace;
+}
+
+function requirePublishBaseBranch(baseBranch: string): string {
+  const branch = baseBranch.trim();
+  if (!branch || branch.length > 200 || !/^[A-Za-z0-9._/-]+$/.test(branch) || branch.startsWith("/") || branch.endsWith("/") || branch.includes("..")) {
+    throw new Error("A valid GitHub base branch is required before publishing a pull request.");
+  }
+  return branch;
+}
+
+function boundedPublisherText(value: string, label: string, maxLength: number): string {
+  const text = value.trim();
+  if (!text) {
+    throw new Error(`${label} cannot be empty.`);
+  }
+  return text.length > maxLength ? text.slice(0, maxLength) : text;
+}
+
+function parsePullRequestCreateOutput(stdout: string): { prNumber: number; prUrl: string } {
+  const output = stdout.trim();
+  try {
+    const data = JSON.parse(output) as { number?: unknown; url?: unknown };
+    const prNumber = Number(data.number);
+    const prUrl = typeof data.url === "string" ? data.url : "";
+    if (Number.isInteger(prNumber) && prNumber > 0 && /^https:\/\/github\.com\/[^/]+\/[^/]+\/pull\/\d+$/.test(prUrl)) {
+      return { prNumber, prUrl };
+    }
+  } catch {
+    const url = output.match(/https:\/\/github\.com\/[^/\s]+\/[^/\s]+\/pull\/(\d+)/);
+    if (url?.[0] && url[1]) {
+      return { prNumber: Number(url[1]), prUrl: url[0] };
+    }
+  }
+  throw new Error("GitHub CLI did not return pull request number and URL.");
+}
+
+function publisherErrorMessage(error: unknown): string {
+  if (error instanceof Error && error.message.trim()) {
+    return error.message.trim();
+  }
+  return String(error);
 }
 
 function deterministicPullRequestNumber(workstreamId: string, agentRunId: string): number {

--- a/packages/orchestrator/test/service.test.ts
+++ b/packages/orchestrator/test/service.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createLocalOrchestrator } from "../src/index.js";
-import { deriveGitHubPullRequestReviewResult } from "../src/service.js";
+import { GitHubCliPullRequestPublisher, deriveGitHubPullRequestReviewResult } from "../src/service.js";
 
 const tempDirs: string[] = [];
 
@@ -751,6 +751,314 @@ describe("LocalOrchestratorService", () => {
     });
 
     await orchestrator.stop();
+  });
+
+  it("publishes completed build-agent changes through git and GitHub CLI", async () => {
+    const dataDir = await createTempDir();
+    const workspacePath = path.join(dataDir, "workspace");
+    const commands: Array<{ command: string; args: string[]; cwd?: string }> = [];
+    const pullRequestPublisher = new GitHubCliPullRequestPublisher({
+      command: async (command, args, options) => {
+        commands.push({ command, args, cwd: options.cwd });
+        if (command === "git" && args.join(" ") === "status --porcelain") {
+          return { stdout: " M packages/orchestrator/src/service.ts\n" };
+        }
+        if (command === "git" && args.join(" ") === "remote get-url origin") {
+          return { stdout: "git@github.com:ss-andrade/mergepilot.git\n" };
+        }
+        if (command === "git" && args.join(" ") === "remote get-url --push --all origin") {
+          return { stdout: "https://github.com/ss-andrade/mergepilot.git\n" };
+        }
+        if (command === "git" && args.join(" ") === "rev-parse HEAD") {
+          return { stdout: "abc123def456\n" };
+        }
+        if (command === "gh" && args[0] === "pr" && args[1] === "create") {
+          return { stdout: "https://github.com/ss-andrade/mergepilot/pull/42\n" };
+        }
+        return { stdout: "" };
+      }
+    });
+    const orchestrator = createLocalOrchestrator({ dataDir, pullRequestPublisher });
+    await orchestrator.start();
+    const workstream = orchestrator.createWorkstream({
+      title: "Real PR",
+      goal: "Publish real build-agent work.",
+      repo: "ss-andrade/mergepilot",
+      githubRepository: { owner: "ss-andrade", name: "mergepilot", defaultBranch: "main" },
+      createdBy: "hermes"
+    });
+    orchestrator.updateWorkstreamStatus(workstream.id, "planning");
+    const plan = orchestrator.proposePlan({ workstreamId: workstream.id });
+    orchestrator.approvePlan({ workstreamId: workstream.id, planId: plan.id });
+    const run = orchestrator.createAgentRun({
+      workstreamId: workstream.id,
+      planId: plan.id,
+      providerId: "codex",
+      role: "build",
+      status: "completed",
+      goal: workstream.goal,
+      workspacePath,
+      branchName: `mergepilot/${workstream.id}/build/run-1`
+    });
+    orchestrator.updateWorkstreamStatus(workstream.id, "awaiting_review");
+
+    const pullRequest = await orchestrator.openPullRequest({ workstreamId: workstream.id, agentRunId: run.id });
+
+    expect(pullRequest).toMatchObject({
+      branchName: run.branchName,
+      commitSha: "abc123def456",
+      prNumber: 42,
+      prUrl: "https://github.com/ss-andrade/mergepilot/pull/42",
+      status: "open"
+    });
+    expect(commands.map((entry) => [entry.command, entry.args])).toEqual([
+      ["git", ["status", "--porcelain"]],
+      ["git", ["remote", "get-url", "origin"]],
+      ["git", ["remote", "get-url", "--push", "--all", "origin"]],
+      ["gh", ["auth", "status"]],
+      ["git", ["checkout", "-B", run.branchName]],
+      ["git", ["add", "-A"]],
+      ["git", ["commit", "-m", "Real PR: build-agent changes", "-m", expect.stringContaining(workstream.id)]],
+      ["git", ["rev-parse", "HEAD"]],
+      ["git", ["push", "--set-upstream", "origin", run.branchName]],
+      ["gh", ["pr", "create", "--repo", "ss-andrade/mergepilot", "--base", "main", "--head", run.branchName, "--title", "Real PR: build-agent changes", "--body", expect.stringContaining(workstream.id)]]
+    ]);
+    expect(commands.every((entry) => entry.cwd === workspacePath)).toBe(true);
+
+    await orchestrator.stop();
+  });
+
+  it("records no-change real publisher runs as failed pull requests requiring human action", async () => {
+    const dataDir = await createTempDir();
+    const pullRequestPublisher = new GitHubCliPullRequestPublisher({
+      command: async () => ({ stdout: "" })
+    });
+    const orchestrator = createLocalOrchestrator({ dataDir, pullRequestPublisher });
+    await orchestrator.start();
+    const workstream = orchestrator.createWorkstream({
+      title: "No changes",
+      goal: "Do not publish empty work.",
+      repo: "ss-andrade/mergepilot",
+      createdBy: "hermes"
+    });
+    orchestrator.updateWorkstreamStatus(workstream.id, "planning");
+    const plan = orchestrator.proposePlan({ workstreamId: workstream.id });
+    orchestrator.approvePlan({ workstreamId: workstream.id, planId: plan.id });
+    const run = orchestrator.createAgentRun({
+      workstreamId: workstream.id,
+      planId: plan.id,
+      providerId: "codex",
+      role: "build",
+      status: "completed",
+      goal: workstream.goal,
+      workspacePath: path.join(dataDir, "workspace"),
+      branchName: `mergepilot/${workstream.id}/build/run-1`
+    });
+    orchestrator.updateWorkstreamStatus(workstream.id, "awaiting_review");
+
+    const pullRequest = await orchestrator.openPullRequest({ workstreamId: workstream.id, agentRunId: run.id });
+
+    expect(pullRequest).toMatchObject({
+      status: "failed",
+      branchName: run.branchName,
+      prNumber: null,
+      prUrl: null,
+      errorMessage: expect.stringMatching(/no file changes/i)
+    });
+    expect(orchestrator.getWorkstream(workstream.id)).toMatchObject({ status: "awaiting_user_input" });
+
+    await orchestrator.stop();
+  });
+
+  it("surfaces missing GitHub CLI authentication as a real publisher failure", async () => {
+    const dataDir = await createTempDir();
+    const pullRequestPublisher = new GitHubCliPullRequestPublisher({
+      command: async (command, args) => {
+        if (command === "git" && args.join(" ") === "status --porcelain") {
+          return { stdout: " M README.md\n" };
+        }
+        if (command === "git" && args.join(" ") === "remote get-url origin") {
+          return { stdout: "https://github.com/ss-andrade/mergepilot.git\n" };
+        }
+        if (command === "git" && args.join(" ") === "remote get-url --push --all origin") {
+          return { stdout: "https://github.com/ss-andrade/mergepilot.git\n" };
+        }
+        if (command === "gh" && args.join(" ") === "auth status") {
+          throw new Error("gh auth status failed");
+        }
+        return { stdout: "" };
+      }
+    });
+    const orchestrator = createLocalOrchestrator({ dataDir, pullRequestPublisher });
+    await orchestrator.start();
+    const workstream = orchestrator.createWorkstream({
+      title: "Auth failure",
+      goal: "Surface GitHub auth failures.",
+      repo: "ss-andrade/mergepilot",
+      createdBy: "hermes"
+    });
+    orchestrator.updateWorkstreamStatus(workstream.id, "planning");
+    const plan = orchestrator.proposePlan({ workstreamId: workstream.id });
+    orchestrator.approvePlan({ workstreamId: workstream.id, planId: plan.id });
+    const run = orchestrator.createAgentRun({
+      workstreamId: workstream.id,
+      planId: plan.id,
+      providerId: "codex",
+      role: "build",
+      status: "completed",
+      goal: workstream.goal,
+      workspacePath: path.join(dataDir, "workspace"),
+      branchName: `mergepilot/${workstream.id}/build/run-1`
+    });
+    orchestrator.updateWorkstreamStatus(workstream.id, "awaiting_review");
+
+    const pullRequest = await orchestrator.openPullRequest({ workstreamId: workstream.id, agentRunId: run.id });
+
+    expect(pullRequest).toMatchObject({
+      status: "failed",
+      errorMessage: expect.stringContaining("gh auth status failed")
+    });
+
+    await orchestrator.stop();
+  });
+
+  it("refuses to publish when the workspace origin does not match the selected repository", async () => {
+    const publisher = new GitHubCliPullRequestPublisher({
+      command: async (command, args) => {
+        if (command === "git" && args.join(" ") === "status --porcelain") {
+          return { stdout: " M README.md\n" };
+        }
+        if (command === "git" && args.join(" ") === "remote get-url origin") {
+          return { stdout: "git@github.com:someone-else/wrong-repo.git\n" };
+        }
+        throw new Error(`Unexpected command: ${command} ${args.join(" ")}`);
+      }
+    });
+
+    await expect(publisher.openPullRequest({
+      workstream: {
+        id: "ws-1",
+        title: "Wrong origin",
+        goal: "Validate workspace remote.",
+        status: "awaiting_review",
+        repo: "ss-andrade/mergepilot",
+        githubRepository: { owner: "ss-andrade", name: "mergepilot", defaultBranch: "main" },
+        createdBy: "hermes",
+        summary: null,
+        createdAt: "2026-05-04T00:00:00.000Z",
+        updatedAt: "2026-05-04T00:00:00.000Z"
+      },
+      agentRun: {
+        id: "run-1",
+        workstreamId: "ws-1",
+        planId: null,
+        providerId: "codex",
+        adapterId: "codex",
+        role: "build",
+        status: "completed",
+        goal: "Validate workspace remote.",
+        workspacePath: "/tmp/workspace",
+        branchName: "mergepilot/ws-1/build/run-1",
+        summary: null,
+        startedAt: null,
+        completedAt: null,
+        createdAt: "2026-05-04T00:00:00.000Z",
+        updatedAt: "2026-05-04T00:00:00.000Z"
+      },
+      title: "Wrong origin",
+      body: "Body"
+    })).rejects.toThrow(/workspace origin/i);
+  });
+
+  it("refuses to publish when the workspace push origin does not match the selected repository", async () => {
+    const publisher = new GitHubCliPullRequestPublisher({
+      command: async (command, args) => {
+        if (command === "git" && args.join(" ") === "status --porcelain") {
+          return { stdout: " M README.md\n" };
+        }
+        if (command === "git" && args.join(" ") === "remote get-url origin") {
+          return { stdout: "https://github.com/ss-andrade/mergepilot.git\n" };
+        }
+        if (command === "git" && args.join(" ") === "remote get-url --push --all origin") {
+          return { stdout: "https://github.com/ss-andrade/mergepilot.git\nssh://git@evil.example.com/some/repo.git\n" };
+        }
+        throw new Error(`Unexpected command: ${command} ${args.join(" ")}`);
+      }
+    });
+
+    await expect(publisher.openPullRequest({
+      workstream: {
+        id: "ws-1",
+        title: "Wrong push origin",
+        goal: "Validate workspace push remote.",
+        status: "awaiting_review",
+        repo: "ss-andrade/mergepilot",
+        githubRepository: { owner: "ss-andrade", name: "mergepilot", defaultBranch: "main" },
+        createdBy: "hermes",
+        summary: null,
+        createdAt: "2026-05-04T00:00:00.000Z",
+        updatedAt: "2026-05-04T00:00:00.000Z"
+      },
+      agentRun: {
+        id: "run-1",
+        workstreamId: "ws-1",
+        planId: null,
+        providerId: "codex",
+        adapterId: "codex",
+        role: "build",
+        status: "completed",
+        goal: "Validate workspace push remote.",
+        workspacePath: "/tmp/workspace",
+        branchName: "mergepilot/ws-1/build/run-1",
+        summary: null,
+        startedAt: null,
+        completedAt: null,
+        createdAt: "2026-05-04T00:00:00.000Z",
+        updatedAt: "2026-05-04T00:00:00.000Z"
+      },
+      title: "Wrong push origin",
+      body: "Body"
+    })).rejects.toThrow(/push origin/i);
+  });
+
+  it("validates repository scope and branch metadata before real publishing", async () => {
+    const publisher = new GitHubCliPullRequestPublisher({
+      command: vi.fn(async () => ({ stdout: "" }))
+    });
+
+    await expect(publisher.openPullRequest({
+      workstream: {
+        id: "ws-1",
+        title: "Bad scope",
+        goal: "Validate repository metadata.",
+        status: "awaiting_review",
+        repo: "ss-andrade/mergepilot",
+        githubRepository: { owner: "other", name: "mergepilot", defaultBranch: "main" },
+        createdBy: "hermes",
+        summary: null,
+        createdAt: "2026-05-04T00:00:00.000Z",
+        updatedAt: "2026-05-04T00:00:00.000Z"
+      },
+      agentRun: {
+        id: "run-1",
+        workstreamId: "ws-1",
+        planId: null,
+        providerId: "codex",
+        adapterId: "codex",
+        role: "build",
+        status: "completed",
+        goal: "Validate repository metadata.",
+        workspacePath: "/tmp/workspace",
+        branchName: "mergepilot/ws-1/build/run-1",
+        summary: null,
+        startedAt: null,
+        completedAt: null,
+        createdAt: "2026-05-04T00:00:00.000Z",
+        updatedAt: "2026-05-04T00:00:00.000Z"
+      },
+      title: "Bad scope",
+      body: "Body"
+    })).rejects.toThrow(/connected GitHub repository/i);
   });
 
   it("keeps active build-agent runs lifecycle-safe until they settle", async () => {


### PR DESCRIPTION
## Summary
- Adds a real Git/GitHub CLI pull-request publisher for completed build-agent workspaces.
- Wires the desktop orchestrator to use the real publisher by default while preserving injectable deterministic publishers for tests.
- Validates repository scope, workspace fetch origin, all push origins, branch/base metadata, and no-change workspaces before any publishing side effects.
- Persists real branch, commit SHA, PR number, URL, and failure state through the existing orchestrator/store path.

## Test plan
- `npm run test -w @mergepilot/orchestrator -- --run test/service.test.ts`
- `npm run test -w @mergepilot/desktop`
- `npm run typecheck -w @mergepilot/orchestrator`
- `npm run typecheck -w @mergepilot/desktop`
- `npm run verify`
- `npm run test:e2e:web`
- `npm run test:e2e:electron` *(runtime spec skipped by existing environment/config)*

## Review
- Codex implemented the initial TDD pass.
- Hermes fixed the unsupported PR-create JSON flag and hardened remote validation.
- Independent blocker reviews found and verified fixes for fetch/push-origin safety before publish side effects.
- Final independent review: no remaining blockers.

Closes #34
