### PR TITLE
Add in-app dogfood preflight panel: build-agent changes

### DIFF
--- a/apps/desktop/src/main/orchestrator-ipc.test.ts
+++ b/apps/desktop/src/main/orchestrator-ipc.test.ts
@@ -380,4 +380,79 @@ describe("orchestrator IPC handlers", () => {
     expect(orchestrator.openPullRequest).not.toHaveBeenCalled();
     expect(orchestrator.listPullRequests).not.toHaveBeenCalled();
   });
+
+  it("runs dogfood preflight through IPC and records sanitized timeline evidence", async () => {
+    const ipc = createFakeIpc();
+    const orchestrator = {
+      start: vi.fn(),
+      stop: vi.fn(),
+      status: vi.fn(),
+      createWorkstream: vi.fn(),
+      listWorkstreams: vi.fn(),
+      getWorkstream: vi.fn(),
+      updateWorkstreamStatus: vi.fn(),
+      appendEvent: vi.fn(async (input) => ({
+        id: "evt-preflight",
+        sequence: 1,
+        createdAt: "2026-05-10T00:00:00.000Z",
+        ...input
+      })),
+      listEvents: vi.fn(),
+      connectGitHubRepository: vi.fn(),
+      listGitHubRepositories: vi.fn(),
+      selectGitHubRepository: vi.fn(),
+      recordGitHubRepositoryConnectionError: vi.fn(),
+      proposePlan: vi.fn(),
+      listPlans: vi.fn(),
+      approvePlan: vi.fn(),
+      rejectPlan: vi.fn(),
+      startBuildAgentRun: vi.fn(),
+      listAgentRuns: vi.fn(),
+      openPullRequest: vi.fn(),
+      listPullRequests: vi.fn(),
+      syncPullRequestReview: vi.fn()
+    };
+
+    registerOrchestratorIpcHandlers(ipc, orchestrator, {
+      runDogfoodPreflight: vi.fn(async () => ({
+        ok: false,
+        cwd: "https://ghp_DO_NOT_PRINT_ME123456789@github.com/owner/repo.git",
+        ranAt: "2026-05-10T00:00:00.000Z",
+        checks: [
+          {
+            id: "github-auth",
+            label: "GitHub CLI auth",
+            status: "fail",
+            detail: "token=DO_NOT_PRINT_ME",
+            remediation: "Run `gh auth login`."
+          }
+        ]
+      }))
+    });
+
+    await expect(
+      ipc.invoke("dogfood:preflight:run", {
+        workstreamId: "ws-1",
+        repo: "ss-andrade/mergepilot"
+      })
+    ).resolves.toMatchObject({
+      ok: false,
+      cwd: "https://github.com/owner/repo.git",
+      checks: [{ id: "github-auth", status: "fail", detail: "[redacted]" }]
+    });
+
+    expect(orchestrator.appendEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workstreamId: "ws-1",
+        type: "human_action_required",
+        message: "Dogfood preflight found blockers before build-agent execution.",
+        payload: expect.objectContaining({
+          action: "dogfood_preflight",
+          ok: false,
+          cwd: "https://github.com/owner/repo.git",
+          checks: [expect.objectContaining({ detail: "[redacted]" })]
+        })
+      })
+    );
+  });
 });

--- a/apps/desktop/src/main/orchestrator-ipc.test.ts
+++ b/apps/desktop/src/main/orchestrator-ipc.test.ts
@@ -193,7 +193,14 @@ describe("orchestrator IPC handlers", () => {
       }))
     };
 
-    registerOrchestratorIpcHandlers(ipc, orchestrator);
+    registerOrchestratorIpcHandlers(ipc, orchestrator, {
+      runDogfoodPreflight: vi.fn(async () => ({
+        ok: true,
+        cwd: "/tmp/mergepilot",
+        ranAt: "2026-05-10T00:00:00.000Z",
+        checks: [{ id: "git", label: "Git", status: "pass", detail: "git version 2.44.0" }]
+      }))
+    });
 
     await expect(ipc.invoke("orchestrator:start")).resolves.toMatchObject({ state: "running", dataDir: "/tmp/data" });
     await expect(
@@ -248,6 +255,12 @@ describe("orchestrator IPC handlers", () => {
     await expect(
       ipc.invoke("plans:reject", { workstreamId: "ws-1", planId: "plan-1", reason: "Needs edits." })
     ).resolves.toMatchObject({ id: "plan-1", status: "rejected" });
+    await expect(
+      ipc.invoke("dogfood:preflight:run", {
+        workstreamId: "ws-1",
+        repo: "ss-andrade/mergepilot"
+      })
+    ).resolves.toMatchObject({ ok: true });
     await expect(ipc.invoke("agents:start-build-run", { workstreamId: "ws-1" })).resolves.toMatchObject({
       id: "run-1",
       status: "completed",
@@ -454,5 +467,7 @@ describe("orchestrator IPC handlers", () => {
         })
       })
     );
+    await expect(ipc.invoke("agents:start-build-run", { workstreamId: "ws-1" })).rejects.toThrow(/preflight/i);
+    expect(orchestrator.startBuildAgentRun).not.toHaveBeenCalled();
   });
 });

--- a/apps/desktop/src/main/orchestrator-ipc.ts
+++ b/apps/desktop/src/main/orchestrator-ipc.ts
@@ -14,8 +14,36 @@ import type {
   WorkstreamStatus
 } from "@mergepilot/orchestrator";
 import { WORKSTREAM_EVENT_TYPES } from "@mergepilot/orchestrator";
+import { existsSync } from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
 
 const workstreamEventTypes = new Set<string>(WORKSTREAM_EVENT_TYPES);
+const secretPattern = /\b(?:ghp|github_pat|gho|ghu|ghs|ghr|sk|xox[baprs])_[A-Za-z0-9_=-]{8,}\b|(?:token|password|secret|authorization|credential)=\S+/gi;
+
+export type DogfoodPreflightStatus = "pass" | "fail" | "skip" | "warning";
+
+export interface DogfoodPreflightCheck {
+  id: string;
+  label: string;
+  status: DogfoodPreflightStatus;
+  detail: string;
+  remediation?: string;
+}
+
+export interface DogfoodPreflightReport {
+  ok: boolean;
+  cwd: string;
+  checks: DogfoodPreflightCheck[];
+  ranAt: string;
+}
+
+export interface RunDogfoodPreflightInput {
+  workstreamId: string;
+  repo: string;
+}
+
+type DogfoodPreflightRunner = (input: RunDogfoodPreflightInput) => Promise<DogfoodPreflightReport>;
 
 export interface OrchestratorIpc {
   handle(channel: string, listener: (event: unknown, ...args: unknown[]) => unknown): void;
@@ -51,8 +79,11 @@ export function registerOrchestratorIpcHandlers(
     | "syncPullRequestReview"
     | "appendEvent"
     | "listEvents"
-  >
+  >,
+  options: { runDogfoodPreflight?: DogfoodPreflightRunner } = {}
 ): void {
+  const runDogfoodPreflight = options.runDogfoodPreflight ?? defaultRunDogfoodPreflight;
+
   ipc.handle("orchestrator:start", async () => {
     await orchestrator.start();
     return orchestrator.status();
@@ -114,6 +145,32 @@ export function registerOrchestratorIpcHandlers(
 
   ipc.handle("agents:start-build-run", (_event, rawInput) => {
     return orchestrator.startBuildAgentRun(parseStartBuildAgentRunInput(rawInput));
+  });
+
+  ipc.handle("dogfood:preflight:run", async (_event, rawInput) => {
+    const input = parseRunDogfoodPreflightInput(rawInput);
+    const report = sanitizeDogfoodPreflightReport(await runDogfoodPreflight(input));
+    await orchestrator.appendEvent({
+      workstreamId: input.workstreamId,
+      type: report.ok ? "command_ran" : "human_action_required",
+      message: report.ok
+        ? "Dogfood preflight passed for selected workstream."
+        : "Dogfood preflight found blockers before build-agent execution.",
+      payload: {
+        surface: "desktop",
+        action: "dogfood_preflight",
+        ok: report.ok,
+        cwd: report.cwd,
+        checks: report.checks.map((check) => ({
+          id: check.id,
+          status: check.status,
+          label: check.label,
+          detail: check.detail,
+          remediation: check.remediation
+        }))
+      }
+    });
+    return report;
   });
 
   ipc.handle("agents:list-runs", (_event, rawInput) => {
@@ -277,6 +334,14 @@ function parseAppendEventInput(rawInput: unknown): AppendWorkstreamEventInput {
   return parsed;
 }
 
+function parseRunDogfoodPreflightInput(rawInput: unknown): RunDogfoodPreflightInput {
+  const input = requireRecord(rawInput);
+  return {
+    workstreamId: parseIdInput(input.workstreamId, "workstreamId"),
+    repo: requireBoundedString(input.repo, "repo", 2048)
+  };
+}
+
 function parseIdInput(rawInput: unknown, field: string): string {
   const value = typeof rawInput === "object" && rawInput !== null && field in rawInput
     ? (rawInput as Record<string, unknown>)[field]
@@ -406,4 +471,58 @@ function isJsonCompatible(value: unknown, seen: Set<object>): boolean {
   }
 
   return Object.values(value as Record<string, unknown>).every((item) => isJsonCompatible(item, seen));
+}
+
+async function defaultRunDogfoodPreflight(input: RunDogfoodPreflightInput): Promise<DogfoodPreflightReport> {
+  const scriptUrl = pathToFileURL(path.resolve(process.cwd(), "scripts/preflight-dogfood.mjs")).href;
+  const module = await import(scriptUrl) as {
+    buildDogfoodPreflightReport(options: { cwd: string }): Promise<Omit<DogfoodPreflightReport, "ranAt">>;
+  };
+  const report = await module.buildDogfoodPreflightReport({
+    cwd: resolvePreflightCwd(input.repo)
+  });
+  return {
+    ...report,
+    ranAt: new Date().toISOString()
+  };
+}
+
+function resolvePreflightCwd(repo: string): string {
+  if (path.isAbsolute(repo)) {
+    return repo;
+  }
+
+  const candidate = path.resolve(process.cwd(), repo);
+  if (repo.startsWith(".") || existsSync(candidate)) {
+    return candidate;
+  }
+
+  return process.cwd();
+}
+
+function sanitizeDogfoodPreflightReport(report: DogfoodPreflightReport): DogfoodPreflightReport {
+  return {
+    ok: Boolean(report.ok),
+    cwd: sanitizeText(report.cwd),
+    ranAt: report.ranAt || new Date().toISOString(),
+    checks: Array.isArray(report.checks)
+      ? report.checks.map((check) => ({
+          id: sanitizeText(check.id).slice(0, 128),
+          label: sanitizeText(check.label).slice(0, 160),
+          status: normalizePreflightStatus(check.status),
+          detail: sanitizeText(check.detail || "Check completed.").slice(0, 500),
+          ...(check.remediation ? { remediation: sanitizeText(check.remediation).slice(0, 500) } : {})
+        }))
+      : []
+  };
+}
+
+function normalizePreflightStatus(status: unknown): DogfoodPreflightStatus {
+  return status === "pass" || status === "fail" || status === "skip" || status === "warning" ? status : "warning";
+}
+
+function sanitizeText(value: unknown): string {
+  return String(value ?? "")
+    .replace(secretPattern, "[redacted]")
+    .replace(/^https:\/\/[^@\s]+@/i, "https://");
 }

--- a/apps/desktop/src/main/orchestrator-ipc.ts
+++ b/apps/desktop/src/main/orchestrator-ipc.ts
@@ -83,6 +83,7 @@ export function registerOrchestratorIpcHandlers(
   options: { runDogfoodPreflight?: DogfoodPreflightRunner } = {}
 ): void {
   const runDogfoodPreflight = options.runDogfoodPreflight ?? defaultRunDogfoodPreflight;
+  const preflightReadinessByWorkstream = new Map<string, boolean>();
 
   ipc.handle("orchestrator:start", async () => {
     await orchestrator.start();
@@ -144,12 +145,17 @@ export function registerOrchestratorIpcHandlers(
   });
 
   ipc.handle("agents:start-build-run", (_event, rawInput) => {
-    return orchestrator.startBuildAgentRun(parseStartBuildAgentRunInput(rawInput));
+    const input = parseStartBuildAgentRunInput(rawInput);
+    if (preflightReadinessByWorkstream.get(input.workstreamId) !== true) {
+      throw new Error("Run and pass dogfood preflight before starting the build agent.");
+    }
+    return orchestrator.startBuildAgentRun(input);
   });
 
   ipc.handle("dogfood:preflight:run", async (_event, rawInput) => {
     const input = parseRunDogfoodPreflightInput(rawInput);
     const report = sanitizeDogfoodPreflightReport(await runDogfoodPreflight(input));
+    preflightReadinessByWorkstream.set(input.workstreamId, report.ok);
     await orchestrator.appendEvent({
       workstreamId: input.workstreamId,
       type: report.ok ? "command_ran" : "human_action_required",
@@ -476,10 +482,11 @@ function isJsonCompatible(value: unknown, seen: Set<object>): boolean {
 async function defaultRunDogfoodPreflight(input: RunDogfoodPreflightInput): Promise<DogfoodPreflightReport> {
   const scriptUrl = pathToFileURL(path.resolve(process.cwd(), "scripts/preflight-dogfood.mjs")).href;
   const module = await import(scriptUrl) as {
-    buildDogfoodPreflightReport(options: { cwd: string }): Promise<Omit<DogfoodPreflightReport, "ranAt">>;
+    buildDogfoodPreflightReport(options: { cwd: string; expectedRepo?: string }): Promise<Omit<DogfoodPreflightReport, "ranAt">>;
   };
   const report = await module.buildDogfoodPreflightReport({
-    cwd: resolvePreflightCwd(input.repo)
+    cwd: resolvePreflightCwd(input.repo),
+    expectedRepo: input.repo
   });
   return {
     ...report,

--- a/apps/desktop/src/preload/preload.cts
+++ b/apps/desktop/src/preload/preload.cts
@@ -164,6 +164,28 @@ interface StartBuildAgentRunInput {
   planId?: string;
 }
 
+type DogfoodPreflightStatus = "pass" | "fail" | "skip" | "warning";
+
+interface DogfoodPreflightCheck {
+  id: string;
+  label: string;
+  status: DogfoodPreflightStatus;
+  detail: string;
+  remediation?: string;
+}
+
+interface DogfoodPreflightReport {
+  ok: boolean;
+  cwd: string;
+  checks: DogfoodPreflightCheck[];
+  ranAt: string;
+}
+
+interface RunDogfoodPreflightInput {
+  workstreamId: string;
+  repo: string;
+}
+
 interface PullRequest {
   id: string;
   workstreamId: string;
@@ -239,6 +261,9 @@ export interface MergePilotDesktopApi {
     startBuildRun(input: StartBuildAgentRunInput): Promise<AgentRun>;
     listRuns(workstreamId: string): Promise<AgentRun[]>;
   };
+  dogfood: {
+    runPreflight(input: RunDogfoodPreflightInput): Promise<DogfoodPreflightReport>;
+  };
   pullRequests: {
     open(input: OpenPullRequestInput): Promise<PullRequest>;
     list(workstreamId: string): Promise<PullRequest[]>;
@@ -284,6 +309,9 @@ const desktopApi: MergePilotDesktopApi = {
   agents: {
     startBuildRun: (input) => ipcRenderer.invoke("agents:start-build-run", input),
     listRuns: (workstreamId) => ipcRenderer.invoke("agents:list-runs", { workstreamId })
+  },
+  dogfood: {
+    runPreflight: (input) => ipcRenderer.invoke("dogfood:preflight:run", input)
   },
   pullRequests: {
     open: (input) => ipcRenderer.invoke("pull-requests:open", input),

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,5 +1,6 @@
 import {
   ActivityIcon,
+  AlertTriangleIcon,
   BellIcon,
   BotIcon,
   CheckCircle2Icon,
@@ -17,6 +18,7 @@ import {
   SparklesIcon,
   SquareIcon,
   SunIcon,
+  XCircleIcon,
   WorkflowIcon
 } from "lucide-react";
 import { FormEvent, ReactNode, useEffect, useMemo, useState } from "react";
@@ -55,6 +57,12 @@ interface AgentRunState {
 interface PullRequestState {
   selectedWorkstreamId: string | null;
   pullRequests: PullRequest[];
+}
+
+interface PreflightState {
+  selectedWorkstreamId: string | null;
+  report: DogfoodPreflightReport | null;
+  running: boolean;
 }
 
 interface WorkstreamFormState {
@@ -150,6 +158,7 @@ export function App() {
   const [planState, setPlanState] = useState<PlanState>({ selectedWorkstreamId: null, plans: [] });
   const [agentRunState, setAgentRunState] = useState<AgentRunState>({ selectedWorkstreamId: null, runs: [] });
   const [pullRequestState, setPullRequestState] = useState<PullRequestState>({ selectedWorkstreamId: null, pullRequests: [] });
+  const [preflightState, setPreflightState] = useState<PreflightState>({ selectedWorkstreamId: null, report: null, running: false });
   const [error, setError] = useState<string | null>(null);
   const [humanAttentionMessage, setHumanAttentionMessage] = useState<string | null>(null);
   const [repositoryError, setRepositoryError] = useState<string | null>(null);
@@ -168,6 +177,8 @@ export function App() {
   const currentPlan = selectedWorkstream
     ? planState.plans.find((plan) => plan.status === "draft") ?? planState.plans.at(-1) ?? null
     : null;
+  const selectedPreflightReport = selectedWorkstream && preflightState.selectedWorkstreamId === selectedWorkstream.id ? preflightState.report : null;
+  const buildAgentBlocked = Boolean(selectedWorkstream && selectedWorkstream.status === "running" && !selectedPreflightReport?.ok);
 
   useEffect(() => {
     window.mergePilot.getRuntimeInfo().then(setRuntimeInfo).catch(() => {
@@ -201,6 +212,7 @@ export function App() {
       setPlanState({ selectedWorkstreamId: null, plans: [] });
       setAgentRunState({ selectedWorkstreamId: null, runs: [] });
       setPullRequestState({ selectedWorkstreamId: null, pullRequests: [] });
+      setPreflightState({ selectedWorkstreamId: null, report: null, running: false });
       return;
     }
 
@@ -326,6 +338,9 @@ export function App() {
     setPlanState({ selectedWorkstreamId: workstreamId, plans });
     setAgentRunState({ selectedWorkstreamId: workstreamId, runs });
     setPullRequestState({ selectedWorkstreamId: workstreamId, pullRequests });
+    if (preflightState.selectedWorkstreamId !== workstreamId) {
+      setPreflightState({ selectedWorkstreamId: workstreamId, report: null, running: false });
+    }
     setSidebarOpen(false);
   }
 
@@ -366,12 +381,39 @@ export function App() {
 
   async function startBuildAgentRun(workstreamId: string) {
     setError(null);
+    const currentPreflight = preflightState.selectedWorkstreamId === workstreamId ? preflightState.report : null;
+    if (!currentPreflight?.ok) {
+      setHumanAttentionMessage("Run and pass dogfood preflight before starting the build agent.");
+      return;
+    }
     try {
       const run = await window.mergePilot.agents.startBuildRun({ workstreamId });
       setHumanAttentionMessage(run.status === "completed" ? "Build agent finished and the workstream is ready for review." : `Build agent ${run.status}.`);
       await refreshOrchestrator(workstreamId);
     } catch (caught) {
       setError(caught instanceof Error ? caught.message : "Unable to start build agent run.");
+    }
+  }
+
+  async function runDogfoodPreflight(workstream: Workstream) {
+    setError(null);
+    setHumanAttentionMessage(null);
+    setPreflightState({ selectedWorkstreamId: workstream.id, report: preflightState.selectedWorkstreamId === workstream.id ? preflightState.report : null, running: true });
+    try {
+      const report = await window.mergePilot.dogfood.runPreflight({
+        workstreamId: workstream.id,
+        repo: workstream.repo
+      });
+      setPreflightState({ selectedWorkstreamId: workstream.id, report, running: false });
+      setHumanAttentionMessage(
+        report.ok
+          ? "Dogfood preflight passed. Build-agent execution is available."
+          : "Dogfood preflight found blockers. Fix failed checks before build-agent execution."
+      );
+      await refreshOrchestrator(workstream.id);
+    } catch (caught) {
+      setPreflightState({ selectedWorkstreamId: workstream.id, report: null, running: false });
+      setError(caught instanceof Error ? caught.message : "Unable to run dogfood preflight.");
     }
   }
 
@@ -830,12 +872,25 @@ export function App() {
                   <h3>Agent runs</h3>
                 </div>
                 {selectedWorkstream?.status === "running" ? (
-                  <Button variant="secondary" onClick={() => void startBuildAgentRun(selectedWorkstream.id)}>
+                  <Button
+                    variant="secondary"
+                    onClick={() => void startBuildAgentRun(selectedWorkstream.id)}
+                    disabled={buildAgentBlocked}
+                    title={buildAgentBlocked ? "Run and pass dogfood preflight before starting a build agent." : undefined}
+                  >
                     <BotIcon aria-hidden="true" />
                     Start build agent
                   </Button>
                 ) : null}
               </div>
+              {selectedWorkstream ? (
+                <DogfoodPreflightPanel
+                  report={selectedPreflightReport}
+                  running={preflightState.running && preflightState.selectedWorkstreamId === selectedWorkstream.id}
+                  workstream={selectedWorkstream}
+                  onRun={() => void runDogfoodPreflight(selectedWorkstream)}
+                />
+              ) : null}
               {agentRunState.runs.length > 0 ? (
                 <div className="mp-agent-run-list">
                   {agentRunState.runs.map((run) => (
@@ -1005,6 +1060,72 @@ export function App() {
       />
     </main>
   );
+}
+
+function DogfoodPreflightPanel({
+  onRun,
+  report,
+  running,
+  workstream
+}: {
+  onRun: () => void;
+  report: DogfoodPreflightReport | null;
+  running: boolean;
+  workstream: Workstream;
+}) {
+  return (
+    <div className="mp-preflight-card" aria-label="Dogfood preflight panel">
+      <div className="mp-section-heading">
+        <div>
+          <p className="mp-eyebrow">Dogfood preflight</p>
+          <h4>Local readiness checks</h4>
+        </div>
+        <Button variant="outline" onClick={onRun} disabled={running}>
+          <ShieldCheckIcon aria-hidden="true" />
+          {running ? "Running..." : "Run preflight"}
+        </Button>
+      </div>
+      <p className="mp-preflight-copy">
+        {report
+          ? `Last run ${formatDate(report.ranAt)} for ${report.cwd}.`
+          : `Run checks before build-agent execution for ${workstream.repo}.`}
+      </p>
+      {report ? (
+        <>
+          <div className="mp-preflight-summary">
+            <Badge tone={report.ok ? "success" : "danger"}>{report.ok ? "ready" : "blocked"}</Badge>
+            <span>{report.ok ? "Critical checks passed." : "Build-agent execution is guarded until failed checks pass."}</span>
+          </div>
+          <div className="mp-preflight-list">
+            {report.checks.map((check) => (
+              <div className="mp-preflight-row" data-status={check.status} key={check.id}>
+                {check.status === "pass" ? <CheckCircle2Icon aria-hidden="true" /> : check.status === "fail" ? <XCircleIcon aria-hidden="true" /> : <AlertTriangleIcon aria-hidden="true" />}
+                <div>
+                  <div className="mp-preflight-row__title">
+                    <strong>{check.label}</strong>
+                    <Badge tone={getPreflightTone(check.status)}>{check.status === "skip" ? "warning" : check.status}</Badge>
+                  </div>
+                  <p>{check.detail}</p>
+                  {check.remediation ? <small>{check.remediation}</small> : null}
+                </div>
+              </div>
+            ))}
+          </div>
+        </>
+      ) : (
+        <div className="mp-preflight-empty">
+          <AlertTriangleIcon aria-hidden="true" />
+          <span>Preflight has not run for this workstream.</span>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function getPreflightTone(status: DogfoodPreflightStatus): "danger" | "success" | "warning" {
+  if (status === "pass") return "success";
+  if (status === "fail") return "danger";
+  return "warning";
 }
 
 function PlanList({ items, ordered = false, title }: { items: string[]; ordered?: boolean; title: string }) {

--- a/apps/web/src/global.d.ts
+++ b/apps/web/src/global.d.ts
@@ -162,6 +162,28 @@ interface StartBuildAgentRunInput {
   planId?: string;
 }
 
+type DogfoodPreflightStatus = "pass" | "fail" | "skip" | "warning";
+
+interface DogfoodPreflightCheck {
+  id: string;
+  label: string;
+  status: DogfoodPreflightStatus;
+  detail: string;
+  remediation?: string;
+}
+
+interface DogfoodPreflightReport {
+  ok: boolean;
+  cwd: string;
+  checks: DogfoodPreflightCheck[];
+  ranAt: string;
+}
+
+interface RunDogfoodPreflightInput {
+  workstreamId: string;
+  repo: string;
+}
+
 interface PullRequest {
   id: string;
   workstreamId: string;
@@ -236,6 +258,9 @@ interface MergePilotDesktopApi {
   agents: {
     startBuildRun(input: StartBuildAgentRunInput): Promise<AgentRun>;
     listRuns(workstreamId: string): Promise<AgentRun[]>;
+  };
+  dogfood: {
+    runPreflight(input: RunDogfoodPreflightInput): Promise<DogfoodPreflightReport>;
   };
   pullRequests: {
     open(input: OpenPullRequestInput): Promise<PullRequest>;

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -675,6 +675,96 @@ kbd {
   background: var(--warning-bg);
 }
 
+.mp-preflight-card {
+  display: grid;
+  gap: 12px;
+  margin-bottom: 14px;
+  padding: 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  background: var(--panel-strong);
+}
+
+.mp-preflight-card h4 {
+  margin: 0;
+  font-size: 0.94rem;
+  line-height: 1.2;
+}
+
+.mp-preflight-copy,
+.mp-preflight-row p,
+.mp-preflight-empty {
+  margin: 0;
+  color: var(--muted-foreground);
+}
+
+.mp-preflight-summary,
+.mp-preflight-empty,
+.mp-preflight-row,
+.mp-preflight-row__title {
+  display: flex;
+  align-items: center;
+}
+
+.mp-preflight-summary,
+.mp-preflight-empty {
+  gap: 9px;
+}
+
+.mp-preflight-list {
+  display: grid;
+  overflow: hidden;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  background: var(--card);
+}
+
+.mp-preflight-row {
+  align-items: flex-start;
+  gap: 10px;
+  padding: 11px;
+}
+
+.mp-preflight-row + .mp-preflight-row {
+  border-top: 1px solid var(--border);
+}
+
+.mp-preflight-row > svg {
+  margin-top: 2px;
+  color: var(--warning);
+}
+
+.mp-preflight-row[data-status="pass"] > svg {
+  color: var(--success);
+}
+
+.mp-preflight-row[data-status="fail"] > svg {
+  color: var(--danger);
+}
+
+.mp-preflight-row > div {
+  display: grid;
+  gap: 4px;
+  min-width: 0;
+  flex: 1;
+}
+
+.mp-preflight-row__title {
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.mp-preflight-row__title strong,
+.mp-preflight-row p,
+.mp-preflight-row small,
+.mp-preflight-copy {
+  overflow-wrap: anywhere;
+}
+
+.mp-preflight-row small {
+  color: var(--foreground);
+}
+
 .mp-timeline__list {
   display: grid;
   overflow: hidden;

--- a/scripts/preflight-dogfood.mjs
+++ b/scripts/preflight-dogfood.mjs
@@ -116,12 +116,39 @@ function githubAuthCheck(cwd, runner) {
   );
 }
 
-function originCheck(cwd, runner) {
+function normalizeGitHubRemote(remoteUrl) {
+  const url = sanitizeText(remoteUrl).trim().replace(/\.git$/, "");
+  const https = url.match(/^https:\/\/github\.com\/([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+)$/i);
+  if (https) return `${https[1]}/${https[2]}`;
+  const ssh = url.match(/^git@github\.com:([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+)$/i);
+  if (ssh) return `${ssh[1]}/${ssh[2]}`;
+  const sshUrl = url.match(/^ssh:\/\/git@github\.com\/([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+)$/i);
+  if (sshUrl) return `${sshUrl[1]}/${sshUrl[2]}`;
+  return null;
+}
+
+function normalizeRepoSlug(repo) {
+  const match = String(repo ?? "").trim().match(/^([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+)$/);
+  return match ? `${match[1]}/${match[2]}` : null;
+}
+
+function originCheck(cwd, runner, expectedRepo) {
   const result = runner("git", ["remote", "get-url", "origin"], { cwd });
   const remote = firstLine(result.stdout).trim();
+  const originRepo = normalizeGitHubRemote(remote);
+  const expected = normalizeRepoSlug(expectedRepo);
 
-  if (result.status === 0 && githubRemotePattern.test(remote)) {
+  if (result.status === 0 && originRepo && (!expected || originRepo.toLowerCase() === expected.toLowerCase())) {
     return pass("github-origin", "GitHub origin remote", sanitizeText(remote));
+  }
+
+  if (result.status === 0 && originRepo && expected) {
+    return fail(
+      "github-origin",
+      "GitHub origin remote",
+      `Origin remote points at ${originRepo}, not ${expected}.`,
+      "Open the matching local clone or reconnect the workstream to the repository that matches this worktree.",
+    );
   }
 
   return fail(
@@ -177,7 +204,7 @@ export async function buildDogfoodPreflightReport(options = {}) {
       remediation: "Install GitHub CLI and ensure `gh --version` succeeds.",
     }),
     githubAuthCheck(cwd, runner),
-    originCheck(cwd, runner),
+    originCheck(cwd, runner, options.expectedRepo),
     await writableWorktreeCheck(cwd, canWriteWorktree),
     normalizeElectronCheck(await electronPreflight(cwd)),
   ];

--- a/scripts/preflight-dogfood.mjs
+++ b/scripts/preflight-dogfood.mjs
@@ -6,6 +6,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 const githubRemotePattern = /github\.com[:/][^/\s]+\/[^/\s]+(?:\.git)?$/i;
+const secretPattern = /\b(?:ghp|github_pat|gho|ghu|ghs|ghr|sk|xox[baprs])_[A-Za-z0-9_=-]{8,}\b|(?:token|password|secret|authorization|credential)=\S+/gi;
 
 function defaultRunner(command, args, options = {}) {
   return spawnSync(command, args, {
@@ -19,25 +20,33 @@ function firstLine(value) {
   return String(value ?? "").split(/\r?\n/).find(Boolean) ?? "";
 }
 
+function sanitizeText(value) {
+  return String(value ?? "")
+    .replace(secretPattern, "[redacted]")
+    .replace(/^https:\/\/[^@\s]+@/i, "https://");
+}
+
 function pass(id, label, detail) {
-  return { id, label, status: "pass", detail };
+  return { id, label, status: "pass", detail: sanitizeText(detail) };
 }
 
 function fail(id, label, detail, remediation) {
-  return { id, label, status: "fail", detail, remediation };
+  return { id, label, status: "fail", detail: sanitizeText(detail), remediation: sanitizeText(remediation) };
 }
 
 function skip(id, label, detail) {
-  return { id, label, status: "skip", detail };
+  return { id, label, status: "skip", detail: sanitizeText(detail) };
 }
 
 function normalizeElectronCheck(check) {
-  const detail = check.detail ?? check.message ?? "Electron dependency check completed.";
+  const detail = sanitizeText(check.detail ?? check.message ?? "Electron dependency check completed.");
+  const remediation = check.remediation ? sanitizeText(check.remediation) : undefined;
   return {
     id: "electron-linux",
     label: "Electron Linux dependencies",
     ...check,
     detail,
+    ...(remediation ? { remediation } : {}),
   };
 }
 
@@ -112,7 +121,7 @@ function originCheck(cwd, runner) {
   const remote = firstLine(result.stdout).trim();
 
   if (result.status === 0 && githubRemotePattern.test(remote)) {
-    return pass("github-origin", "GitHub origin remote", remote.replace(/^https:\/\/[^@]+@/i, "https://"));
+    return pass("github-origin", "GitHub origin remote", sanitizeText(remote));
   }
 
   return fail(

--- a/tests/preflight-dogfood.test.mjs
+++ b/tests/preflight-dogfood.test.mjs
@@ -146,4 +146,25 @@ describe("dogfood preflight", () => {
     assert.match(output, /\[redacted\]/);
     assert.match(output, /https:\/\/github\.com\/owner\/repo\.git/);
   });
+
+  it("fails when the GitHub origin does not match the expected repository", async () => {
+    const runner = fakeRunner({
+      "codex --version": success("codex-cli 1.0.0\n"),
+      "git --version": success("git version 2.44.0\n"),
+      "gh --version": success("gh version 2.71.0\n"),
+      "gh auth status": success("github.com\n"),
+      "git remote get-url origin": success("https://github.com/other/repo.git\n"),
+    });
+
+    const report = await buildDogfoodPreflightReport({
+      cwd: "/repo",
+      expectedRepo: "owner/repo",
+      runner: runner.run,
+      electronPreflight: async () => ({ status: "skip", detail: "Only required on Linux hosts." }),
+      canWriteWorktree: async () => true,
+    });
+
+    assert.equal(report.ok, false);
+    assert.match(formatDogfoodPreflightReport(report), /other\/repo, not owner\/repo/);
+  });
 });

--- a/tests/preflight-dogfood.test.mjs
+++ b/tests/preflight-dogfood.test.mjs
@@ -120,4 +120,30 @@ describe("dogfood preflight", () => {
     assert.doesNotMatch(output, /Dogfood preflight failed unexpectedly/);
     assert.doesNotMatch(output, /ENOENT/);
   });
+
+  it("sanitizes tokens from successful details and injected check output", async () => {
+    const runner = fakeRunner({
+      "codex --version": success("codex-cli token=DO_NOT_PRINT_ME\n"),
+      "git --version": success("git version 2.44.0\n"),
+      "gh --version": success("gh version 2.71.0\n"),
+      "gh auth status": success("github.com\n"),
+      "git remote get-url origin": success("https://ghp_DO_NOT_PRINT_ME123456789@github.com/owner/repo.git\n"),
+    });
+
+    const report = await buildDogfoodPreflightReport({
+      cwd: "/repo",
+      runner: runner.run,
+      electronPreflight: async () => ({
+        status: "fail",
+        detail: "Missing dependency with password=DO_NOT_PRINT_ME",
+        remediation: "Run safe package guidance.",
+      }),
+      canWriteWorktree: async () => true,
+    });
+    const output = formatDogfoodPreflightReport(report);
+
+    assert.doesNotMatch(output, /DO_NOT_PRINT_ME/);
+    assert.match(output, /\[redacted\]/);
+    assert.match(output, /https:\/\/github\.com\/owner\/repo\.git/);
+  });
 });

--- a/tests/runtime/electron.spec.ts
+++ b/tests/runtime/electron.spec.ts
@@ -34,7 +34,7 @@ test("built Electron app persists workstreams across restarts in an isolated use
       }
     });
 
-    await expect(page.getByRole("heading", { name: "MergePilot app shell" })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Delivery Control" })).toBeVisible();
     await expect(page.getByText(/^Electron \d/)).toBeVisible();
     const actualUserDataDir = await electronApp.evaluate(({ app }) => app.getPath("userData"));
     expect(actualUserDataDir).toBe(userDataDir);
@@ -47,20 +47,33 @@ test("built Electron app persists workstreams across restarts in an isolated use
     await firstRun.page.getByRole("button", { name: "Start" }).click();
     await expect(firstRun.page.getByText(userDataDir, { exact: false })).toBeVisible();
 
-    await firstRun.page.getByRole("button", { name: "New Workstream" }).click();
-    await expect(firstRun.page.getByText("1 persisted workstream(s)")).toBeVisible();
-    await expect(firstRun.page.getByText("user_message")).toBeVisible();
-
-    await firstRun.page.getByRole("button", { name: "Add event" }).click();
-    await expect(firstRun.page.getByText("coordinator_message")).toBeVisible();
+    const created = await firstRun.page.evaluate(async () => {
+      const workstream = await (window as any).mergePilot.workstreams.create({
+        title: "Persisted Electron workstream",
+        goal: "Verify Electron persistence through the preload bridge.",
+        repo: "ss-andrade/mergepilot",
+        createdBy: "electron-e2e",
+        summary: "Created by Electron E2E persistence test."
+      });
+      await (window as any).mergePilot.events.append({
+        workstreamId: workstream.id,
+        type: "coordinator_message",
+        message: "Persisted coordinator event from Electron E2E."
+      });
+      return { workstreamId: workstream.id };
+    });
     await firstRun.electronApp.close();
 
     const secondRun = await launchApp();
     await secondRun.page.getByRole("button", { name: "Start" }).click();
-    await expect(secondRun.page.getByText("1 persisted workstream(s)")).toBeVisible();
-    await expect(secondRun.page.getByRole("heading", { name: "Workstream 1" })).toBeVisible();
-    await expect(secondRun.page.getByText("user_message")).toBeVisible();
-    await expect(secondRun.page.getByText("coordinator_message")).toBeVisible();
+    await expect(secondRun.page.getByRole("region", { name: "Workstream detail" }).getByRole("heading", { name: "Persisted Electron workstream" })).toBeVisible();
+    const persisted = await secondRun.page.evaluate(async (workstreamId) => {
+      const workstream = await (window as any).mergePilot.workstreams.get(workstreamId);
+      const events = await (window as any).mergePilot.events.list(workstreamId);
+      return { workstream, events };
+    }, created.workstreamId);
+    expect(persisted.workstream?.title).toBe("Persisted Electron workstream");
+    expect(persisted.events.some((event) => event.type === "coordinator_message")).toBe(true);
     await secondRun.electronApp.close();
 
     expect(runtimeFailures).toEqual([]);

--- a/tests/runtime/renderer.spec.ts
+++ b/tests/runtime/renderer.spec.ts
@@ -353,6 +353,35 @@ test("web renderer runs against a mocked mergePilot bridge", async ({ page }) =>
         },
         listRuns: async (workstreamId) => agentRuns.filter((run) => run.workstreamId === workstreamId)
       },
+      dogfood: {
+        runPreflight: async ({ workstreamId, repo }) => {
+          const created: WorkstreamEvent = {
+            id: `event-${sequence + 1}`,
+            workstreamId,
+            sequence: sequence + 1,
+            type: "command_ran",
+            message: "Dogfood preflight passed for selected workstream.",
+            payload: { action: "dogfood_preflight", ok: true, repo },
+            createdAt: now
+          };
+          sequence += 1;
+          events.push(created);
+          return {
+            ok: true,
+            cwd: "/tmp/mergepilot-renderer-mock/worktree",
+            ranAt: now,
+            checks: [
+              { id: "codex", label: "Codex CLI", status: "pass", detail: "codex-cli 1.2.3" },
+              { id: "git", label: "Git", status: "pass", detail: "git version 2.44.0" },
+              { id: "github-cli", label: "GitHub CLI", status: "pass", detail: "gh version 2.71.0" },
+              { id: "github-auth", label: "GitHub CLI auth", status: "pass", detail: "Authenticated for GitHub CLI operations." },
+              { id: "github-origin", label: "GitHub origin remote", status: "pass", detail: "git@github.com:ss-andrade/mergepilot.git" },
+              { id: "writable-worktree", label: "Writable worktree", status: "pass", detail: "Current worktree accepts local writes." },
+              { id: "electron-linux", label: "Electron Linux dependencies", status: "skip", detail: "Only required on Linux hosts." }
+            ] satisfies DogfoodPreflightCheck[]
+          };
+        }
+      },
       pullRequests: {
         open: async ({ workstreamId, agentRunId }) => {
           const workstream = workstreams.find((item) => item.id === workstreamId);
@@ -450,6 +479,13 @@ test("web renderer runs against a mocked mergePilot bridge", async ({ page }) =>
   await expect(page.getByRole("region", { name: "Coordinator plan" })).toContainText("approved");
   await expect(page.getByRole("region", { name: "Event timeline" })).toContainText("plan_approved");
   await expect(page.getByRole("region", { name: "Workstream detail" })).toContainText("running");
+  await expect(page.getByRole("region", { name: "Agent runs" })).toContainText("Preflight has not run for this workstream.");
+  await expect(page.getByRole("button", { name: "Start build agent" })).toBeDisabled();
+  await page.getByRole("button", { name: "Run preflight" }).click();
+  await expect(page.getByLabel("Dogfood preflight panel")).toContainText("Codex CLI");
+  await expect(page.getByLabel("Dogfood preflight panel")).toContainText("warning");
+  await expect(page.getByRole("region", { name: "Event timeline" })).toContainText("Dogfood preflight passed");
+  await expect(page.getByRole("button", { name: "Start build agent" })).toBeEnabled();
   await page.getByRole("button", { name: "Start build agent" }).click();
   await expect(page.getByRole("region", { name: "Agent runs" })).toContainText("completed");
   await expect(page.getByRole("region", { name: "Agent runs" })).toContainText("Mock build agent completed the approved task.");


### PR DESCRIPTION
## Summary
- Adds an in-app dogfood preflight panel for selected repositories, exposed through the desktop preload bridge and renderer UI.
- Reuses the existing dogfood preflight checks for Codex CLI, Git, GitHub CLI/auth, GitHub origin, writable worktree, and Electron Linux dependencies.
- Records preflight results in the workstream timeline and enforces a build-agent readiness gate before starting Codex.
- Strengthens preflight sanitization/expected-repo matching and updates runtime tests for the current app shell.

## Verification
- `npm run test:dogfood`
- `npm run test -w @mergepilot/desktop`
- `npm run verify`
- `npm run test:e2e:web`
- `xvfb-run -a npm run test:e2e:electron`

## Dogfood evidence
- Created by MergePilot running on MergePilot itself.
- Workstream: `38273590-c34b-465a-ac3a-63b82811e549`
- Agent run: `run-mozyic6x-ouczcc`
- Branch: `mergepilot/38273590-c34b-465a-ac3a-63b82811e549/build/run-mozyic6x-ouczcc`

## Notes
- The first Codex pass opened this PR; Hermes then independently reviewed, found gating/expected-repo gaps, patched them, and pushed follow-up commits.
- No secrets or raw stderr are intentionally surfaced in preflight output.
